### PR TITLE
Add FF7-style equipment menu

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -6,6 +6,7 @@ import Menu from './components/Menu/Menu';
 import Landing from "./pages/Landing/Landing";
 import Projects from "./pages/Projects/Projects";
 import Skills from "./pages/Skills/SkillsContent";
+import Equip from "./pages/Equip/Equip";
 import MemCardSelector from "./components/MemCardSelector/MemCardSelector";
 import Config from "./pages/Config/Config";
 
@@ -44,6 +45,7 @@ function App() {
           <Routes>
             <Route path="/" element={<Landing />} />
             <Route path="/skills" element={<Skills />} />
+            <Route path="/equip" element={<Equip />} />
             <Route path="/projects" element={<Projects />} />
             <Route path="/history" element={<MemCardSelector />} />
             <Route path="/config" element={<Config />} />

--- a/frontend/src/components/MateriaSlotPreview/MateriaSlotPreview.module.scss
+++ b/frontend/src/components/MateriaSlotPreview/MateriaSlotPreview.module.scss
@@ -1,0 +1,33 @@
+.equipmentContainer {
+    background-color: rgba(255, 255, 255, 0.15);
+    border-top: 2.2px solid rgba(0, 0, 0, 0.4);
+    border-right: 2.2px solid rgba(255, 255, 255, 0.2);
+    border-bottom: 2.2px solid rgba(255, 255, 255, 0.2);
+    border-left: 2.2px solid rgba(0, 0, 0, 0.4);
+    height: 2.7rem;
+    margin-top: 0.25rem;
+    padding-left: 0.5rem;
+    border-radius: 2px;
+}
+
+.materiaSlot {
+    background-image: url("/materia-slot.png");
+    background-repeat: no-repeat;
+    background-size: contain;
+    height: 40px;
+    width: 40px;
+    margin-right: 0.5rem;
+}
+
+.materiaSlot+.materiaSlot:after {
+    content: "";
+    background-image: url("/materia-connector.png");
+    background-repeat: no-repeat;
+    background-size: cover;
+    position: absolute;
+    top: 50%;
+    left: calc(50% - 6px);
+    width: 30px;
+    height: 17px;
+    transform: translate(-50%, -50%);
+}

--- a/frontend/src/components/MateriaSlotPreview/MateriaSlotPreview.tsx
+++ b/frontend/src/components/MateriaSlotPreview/MateriaSlotPreview.tsx
@@ -1,0 +1,21 @@
+import styles from "./MateriaSlotPreview.module.scss";
+
+interface materiaSlotPreviewProps {
+    multiSlots?: number,
+    singleSlots?: number,
+}
+
+const MateriaSlotPreview: React.FC<materiaSlotPreviewProps> = ({ multiSlots = 0, singleSlots = 0 }) => {
+    return (
+        <div className={`${styles.equipmentContainer} flex`}>
+            {Array.from({ length: multiSlots + singleSlots }).map((_, index) => (
+                <div key={index} className="flex relative">
+                    <div className={styles.materiaSlot}></div>
+                    {index < multiSlots && <div className={styles.materiaSlot}></div>}
+                </div>
+            ))}
+        </div>
+    );
+};
+
+export default MateriaSlotPreview;

--- a/frontend/src/components/contentBox/ContentBox.module.scss
+++ b/frontend/src/components/contentBox/ContentBox.module.scss
@@ -55,7 +55,8 @@
         padding-left: 2rem;
     }
 
-    &[data-label="skillsDescription"] {
+    &[data-label="skillsDescription"],
+    &[data-label="equipDescription"] {
         padding-left: 2rem;
         padding-top: 1.2rem;
         width: 100%;
@@ -73,7 +74,8 @@
         padding-right: 2rem;
     }
 
-    &[data-label="skillsHeader"] {
+    &[data-label="skillsHeader"],
+    &[data-label="equipHeader"] {
         width: 100%;
     }
 
@@ -84,6 +86,24 @@
 
     &[data-label="skillsContentRight"] {
         width: 42%;
+    }
+
+    &[data-label="equipSlots"] {
+        width: 59%;
+        padding-left: 2.5rem;
+        padding-right: 2.4rem;
+    }
+
+    &[data-label="equipStats"] {
+        width: 59%;
+        padding-left: 2.5rem;
+        padding-right: 2.4rem;
+        padding-top: 2rem;
+    }
+
+    &[data-label="equipContentRight"] {
+        width: 42%;
+        padding-left: 2rem;
     }
 
     &[data-label="historySaveMeta"] {

--- a/frontend/src/context/defaults.tsx
+++ b/frontend/src/context/defaults.tsx
@@ -1,4 +1,4 @@
-import type { WindowColor } from "./types";
+import type { WindowColor, CurrentEquipment } from "./types";
 
 export const defaultWindowColor: WindowColor = {
     topLeft: [2, 34, 186],
@@ -9,5 +9,11 @@ export const defaultWindowColor: WindowColor = {
 
 export const defaultMateriaLoadout: (number | null)[][] = [
     [1, null, 2, 3, 4, 9, null, 10],
-    [5, 6, 7, 8, null],
+    [5, 6, 7, 8, null, null],
 ];
+
+export const defaultEquipment: CurrentEquipment = {
+    weapon: 1,
+    armor: 101,
+    accessory: null,
+};

--- a/frontend/src/context/reducer.tsx
+++ b/frontend/src/context/reducer.tsx
@@ -1,5 +1,5 @@
 import type { State, Action } from "./types";
-import { defaultWindowColor, defaultMateriaLoadout } from "./defaults";
+import { defaultWindowColor, defaultMateriaLoadout, defaultEquipment } from "./defaults";
 
 export const reducer = (state: State, action: Action): State => {
     switch (action.type) {
@@ -17,6 +17,8 @@ export const reducer = (state: State, action: Action): State => {
             return { ...state, currentMana: action.payload };
         case "SET_CURRENT_MATERIA":
             return { ...state, currentMateria: action.payload };
+        case "SET_CURRENT_EQUIPMENT":
+            return { ...state, currentEquipment: action.payload };
         case "INCREMENT_SECONDS":
             return { ...state, seconds: state.seconds + 1 };
         default:
@@ -33,4 +35,5 @@ export const initialState: State = {
     currentHealth: null,
     currentMana: null,
     currentMateria: structuredClone(defaultMateriaLoadout),
+    currentEquipment: structuredClone(defaultEquipment),
 };

--- a/frontend/src/context/types.tsx
+++ b/frontend/src/context/types.tsx
@@ -2,6 +2,9 @@
 export type PartyMemberType = { id: number; name: string; limit_level: number; age_epoch: number; hp: number; mp: number; image_path: string; };
 export type HistoryType = { id: number; name: string; link: string; user: string; level: number; role: string; year: string; image_path: string; };
 export type SkillType = { id: number; name: string; color: "green" | "red" | "yellow" | "blue" | "pink" | null; description: string; score: number; };
+export type EquipmentStats = { attack?: number; attackPct?: number; magicAtk?: number; defense?: number; defensePct?: number; magicDefPct?: number; };
+export type EquipmentItemType = { id: number; name: string; type: "weapon" | "armor" | "accessory"; description: string; stats: EquipmentStats; slots?: { multiSlots: number; singleSlots: number }; };
+export type CurrentEquipment = { weapon: number; armor: number; accessory: number | null; };
 export type MenuItem = { id: string; name: string; title?: string; path?: string; position?: number; };
 
 export type WindowCorner = "topLeft" | "topRight" | "bottomLeft" | "bottomRight" | null;
@@ -19,6 +22,7 @@ export interface State {
     currentHealth: number | null;
     currentMana: number | null;
     currentMateria: (number | null)[][]
+    currentEquipment: CurrentEquipment;
     isSoundEnabled: boolean;
     isCRTEnabled: boolean;
 }
@@ -30,6 +34,7 @@ export type Action =
     | { type: "SET_CURRENT_HEALTH"; payload: number | null }
     | { type: "SET_CURRENT_MANA"; payload: number | null }
     | { type: "SET_CURRENT_MATERIA"; payload: (number | null)[][] }
+    | { type: "SET_CURRENT_EQUIPMENT"; payload: CurrentEquipment }
     | { type: "SET_IS_SOUND_ENABLED"; payload: boolean }
     | { type: "SET_IS_CRT_ENABLED"; payload: boolean }
 

--- a/frontend/src/data/equipment.json
+++ b/frontend/src/data/equipment.json
@@ -3,92 +3,72 @@
         "id": 1,
         "name": "Mouse",
         "type": "weapon",
-        "description": "Standard issue pointing device. Reliable, if uninspiring.",
+        "description": "A standard issue 800dpi Mouse.",
         "stats": { "attack": 18, "attackPct": 96 },
         "slots": { "multiSlots": 3, "singleSlots": 2 }
     },
     {
         "id": 2,
-        "name": "Trackball",
+        "name": "Stylus",
         "type": "weapon",
-        "description": "Precise thumb-driven aim. Never needs a mousepad.",
+        "description": "A precision pointing device made to emulate a pen or pencil.",
         "stats": { "attack": 24, "attackPct": 92, "magicAtk": 4 },
         "slots": { "multiSlots": 2, "singleSlots": 2 }
-    },
-    {
-        "id": 3,
-        "name": "Gaming Mouse",
-        "type": "weapon",
-        "description": "16000 DPI and RGB underglow. Casts Haste on click events.",
-        "stats": { "attack": 33, "attackPct": 99 },
-        "slots": { "multiSlots": 4, "singleSlots": 0 }
-    },
-    {
-        "id": 4,
-        "name": "Graphics Tablet",
-        "type": "weapon",
-        "description": "Pressure-sensitive stylus. Strong against pixels.",
-        "stats": { "attack": 21, "attackPct": 90, "magicAtk": 12 },
-        "slots": { "multiSlots": 1, "singleSlots": 4 }
     },
     {
         "id": 101,
         "name": "Keyboard",
         "type": "armor",
-        "description": "Trusty membrane board. Gets the job done.",
+        "description": "A standard issue QWERTY Keyboard",
         "stats": { "defense": 20, "defensePct": 6, "magicDefPct": 3 },
         "slots": { "multiSlots": 2, "singleSlots": 2 }
     },
     {
         "id": 102,
-        "name": "Mech Keyboard",
+        "name": "Graphics Tablet",
         "type": "armor",
-        "description": "Clicky blue switches. Nearby coworkers take 10 sanity damage.",
+        "description": "A pressure-sensitive screen interface",
         "stats": { "defense": 32, "defensePct": 8, "magicDefPct": 5 },
         "slots": { "multiSlots": 3, "singleSlots": 1 }
     },
     {
-        "id": 103,
-        "name": "Split Ergo",
-        "type": "armor",
-        "description": "Ortholinear split board. Wrists fully shielded.",
-        "stats": { "defense": 26, "defensePct": 14, "magicDefPct": 10 },
-        "slots": { "multiSlots": 1, "singleSlots": 3 }
-    },
-    {
-        "id": 104,
-        "name": "60% Keyboard",
-        "type": "armor",
-        "description": "No arrow keys, no function row, no fear.",
-        "stats": { "defense": 16, "defensePct": 18, "magicDefPct": 8 },
-        "slots": { "multiSlots": 2, "singleSlots": 0 }
-    },
-    {
         "id": 201,
-        "name": "Headset",
+        "name": "Audio Headset",
         "type": "accessory",
-        "description": "Noise cancelling. Grants immunity to open office chatter.",
-        "stats": { "magicDefPct": 8 }
+        "description": "Applies [Silence]",
+        "stats": {},
+        "slots": { "multiSlots": 0, "singleSlots": 0 }
     },
     {
         "id": 202,
         "name": "Wrist Rest",
         "type": "accessory",
-        "description": "Memory foam support. Prevents fatigue on long coding sessions.",
-        "stats": { "defensePct": 4, "defense": 5 }
+        "description": "Raises [Comfort]",
+        "stats": {},
+        "slots": { "multiSlots": 0, "singleSlots": 0 }
     },
     {
         "id": 203,
-        "name": "4K Monitor",
+        "name": "Dual Monitors",
         "type": "accessory",
-        "description": "Doubles field of vision. Casts Sense on hidden bugs.",
-        "stats": { "attackPct": 2, "magicAtk": 6 }
+        "description": "Removes [Darkness]",
+        "stats": {},
+        "slots": { "multiSlots": 0, "singleSlots": 0 }
     },
     {
         "id": 204,
         "name": "Standing Desk",
         "type": "accessory",
-        "description": "Raises Evade. Mostly used in the sitting position.",
-        "stats": { "attack": 4, "defense": 4 }
+        "description": "Raises [Evade]",
+        "stats": {},
+        "slots": { "multiSlots": 0, "singleSlots": 0 }
+    },
+        {
+        "id": 205,
+        "name": "Ergonomic Chair",
+        "type": "accessory",
+        "description": "Raises [Comfort]",
+        "stats": {},
+        "slots": { "multiSlots": 0, "singleSlots": 0 }
     }
 ]

--- a/frontend/src/data/equipment.json
+++ b/frontend/src/data/equipment.json
@@ -1,0 +1,94 @@
+[
+    {
+        "id": 1,
+        "name": "Mouse",
+        "type": "weapon",
+        "description": "Standard issue pointing device. Reliable, if uninspiring.",
+        "stats": { "attack": 18, "attackPct": 96 },
+        "slots": { "multiSlots": 3, "singleSlots": 2 }
+    },
+    {
+        "id": 2,
+        "name": "Trackball",
+        "type": "weapon",
+        "description": "Precise thumb-driven aim. Never needs a mousepad.",
+        "stats": { "attack": 24, "attackPct": 92, "magicAtk": 4 },
+        "slots": { "multiSlots": 2, "singleSlots": 2 }
+    },
+    {
+        "id": 3,
+        "name": "Gaming Mouse",
+        "type": "weapon",
+        "description": "16000 DPI and RGB underglow. Casts Haste on click events.",
+        "stats": { "attack": 33, "attackPct": 99 },
+        "slots": { "multiSlots": 4, "singleSlots": 0 }
+    },
+    {
+        "id": 4,
+        "name": "Graphics Tablet",
+        "type": "weapon",
+        "description": "Pressure-sensitive stylus. Strong against pixels.",
+        "stats": { "attack": 21, "attackPct": 90, "magicAtk": 12 },
+        "slots": { "multiSlots": 1, "singleSlots": 4 }
+    },
+    {
+        "id": 101,
+        "name": "Keyboard",
+        "type": "armor",
+        "description": "Trusty membrane board. Gets the job done.",
+        "stats": { "defense": 20, "defensePct": 6, "magicDefPct": 3 },
+        "slots": { "multiSlots": 2, "singleSlots": 2 }
+    },
+    {
+        "id": 102,
+        "name": "Mech Keyboard",
+        "type": "armor",
+        "description": "Clicky blue switches. Nearby coworkers take 10 sanity damage.",
+        "stats": { "defense": 32, "defensePct": 8, "magicDefPct": 5 },
+        "slots": { "multiSlots": 3, "singleSlots": 1 }
+    },
+    {
+        "id": 103,
+        "name": "Split Ergo",
+        "type": "armor",
+        "description": "Ortholinear split board. Wrists fully shielded.",
+        "stats": { "defense": 26, "defensePct": 14, "magicDefPct": 10 },
+        "slots": { "multiSlots": 1, "singleSlots": 3 }
+    },
+    {
+        "id": 104,
+        "name": "60% Keyboard",
+        "type": "armor",
+        "description": "No arrow keys, no function row, no fear.",
+        "stats": { "defense": 16, "defensePct": 18, "magicDefPct": 8 },
+        "slots": { "multiSlots": 2, "singleSlots": 0 }
+    },
+    {
+        "id": 201,
+        "name": "Headset",
+        "type": "accessory",
+        "description": "Noise cancelling. Grants immunity to open office chatter.",
+        "stats": { "magicDefPct": 8 }
+    },
+    {
+        "id": 202,
+        "name": "Wrist Rest",
+        "type": "accessory",
+        "description": "Memory foam support. Prevents fatigue on long coding sessions.",
+        "stats": { "defensePct": 4, "defense": 5 }
+    },
+    {
+        "id": 203,
+        "name": "4K Monitor",
+        "type": "accessory",
+        "description": "Doubles field of vision. Casts Sense on hidden bugs.",
+        "stats": { "attackPct": 2, "magicAtk": 6 }
+    },
+    {
+        "id": 204,
+        "name": "Standing Desk",
+        "type": "accessory",
+        "description": "Raises Evade. Mostly used in the sitting position.",
+        "stats": { "attack": 4, "defense": 4 }
+    }
+]

--- a/frontend/src/data/menu.json
+++ b/frontend/src/data/menu.json
@@ -10,34 +10,39 @@
         "position": 1
     },
     {
+        "id": "equip",
+        "name": "Equip",
+        "position": 2
+    },
+    {
         "id": "history",
         "name": "History",
-        "position": 2
+        "position": 3
     },
     {
         "id": "config",
         "name": "Config",
-        "position": 3
+        "position": 4
     },
     {
         "id": "resume",
         "name": "Resume",
         "title": "My Resume PDF",
         "path": "/Jamie_Pates_Resume_2025.pdf",
-        "position": 5
+        "position": 6
     },
     {
         "id": "github",
         "name": "Github",
         "title": "My Github Page",
         "path": "https://github.com/Cyanoxide",
-        "position": 6
+        "position": 7
     },
     {
         "id": "donate",
         "name": "Donate",
         "title": "My Ko-Fi Donation Page",
         "path": "https://ko-fi.com/cyanoxide",
-        "position": 7
+        "position": 8
     }
 ]

--- a/frontend/src/pages/Equip/Equip.module.scss
+++ b/frontend/src/pages/Equip/Equip.module.scss
@@ -1,0 +1,41 @@
+.equipRow,
+.equipmentItem {
+    cursor: pointer;
+
+    &:hover:after {
+        content: "";
+        position: absolute;
+        margin-left: -73px;
+        background-image: url("/cursor.png");
+        width: 76px;
+        height: 46px;
+        background-size: contain;
+        background-repeat: no-repeat;
+        z-index: 1;
+        pointer-events: none;
+    }
+}
+
+.equipRow[data-active=true]:after {
+    content: "";
+    position: absolute;
+    margin-left: -73px;
+    background-image: url("/cursor.png");
+    width: 76px;
+    height: 46px;
+    background-size: contain;
+    background-repeat: no-repeat;
+    z-index: 1;
+    pointer-events: none;
+    animation: blinking 0.15s linear infinite;
+}
+
+@keyframes blinking {
+    0% {
+        opacity: 1;
+    }
+
+    100% {
+        opacity: 0;
+    }
+}

--- a/frontend/src/pages/Equip/Equip.tsx
+++ b/frontend/src/pages/Equip/Equip.tsx
@@ -1,0 +1,154 @@
+import { useState } from "react";
+import { useContext } from "../../context/context";
+
+import ContentBox from "../../components/ContentBox/ContentBox";
+import PartyMember from "../../components/PartyMember/PartyMember";
+import MateriaSlotPreview from "../../components/MateriaSlotPreview/MateriaSlotPreview";
+import textToSprite from "../../util/textToSprite";
+import playSound from "../../util/sounds";
+import { getEquipmentById, getDerivedStats, slotCount, resizeMateriaRow } from "../../util/equipment";
+import equipmentJSON from "../../data/equipment.json";
+import type { EquipmentItemType, EquipmentStats } from "../../context/types";
+
+import styles from "./Equip.module.scss";
+
+type EquipmentCategory = "weapon" | "armor" | "accessory";
+
+const CATEGORIES: { key: EquipmentCategory; label: string }[] = [
+    { key: "weapon", label: "Wpn." },
+    { key: "armor", label: "Arm." },
+    { key: "accessory", label: "Acc." },
+];
+
+const STAT_ROWS: { key: keyof EquipmentStats; label: string }[] = [
+    { key: "attack", label: "Attack" },
+    { key: "attackPct", label: "Attack%" },
+    { key: "defense", label: "Defense" },
+    { key: "defensePct", label: "Defense%" },
+    { key: "magicAtk", label: "Magic atk" },
+    { key: "magicDefPct", label: "Magic def%" },
+];
+
+function Equip() {
+    const { isSoundEnabled, currentMateria, currentEquipment, dispatch } = useContext();
+
+    const [selectedCategory, setSelectedCategory] = useState<EquipmentCategory | null>(null);
+    const [hoveredCategory, setHoveredCategory] = useState<EquipmentCategory | null>(null);
+    const [hoveredItem, setHoveredItem] = useState<EquipmentItemType | null>(null);
+    const [lastEquipped, setLastEquipped] = useState<EquipmentItemType | null>(null);
+
+    const activeCategory = hoveredCategory ?? selectedCategory;
+    const equippedItem = activeCategory ? getEquipmentById(currentEquipment[activeCategory]) : undefined;
+    const previewItem = hoveredItem ?? equippedItem;
+    const stickyPreview = previewItem ?? lastEquipped;
+    const slotItem = (stickyPreview?.type === "accessory") ? null : stickyPreview;
+    const currentStats = getDerivedStats(currentEquipment);
+    const newStats = hoveredItem ? getDerivedStats({ ...currentEquipment, [hoveredItem.type]: hoveredItem.id }) : currentStats;
+
+    const categoryItems = activeCategory ? (equipmentJSON as EquipmentItemType[]).filter(item => item.type === activeCategory) : [];
+
+    const handleCategoryEnter = (category: EquipmentCategory) => {
+        playSound("select", isSoundEnabled);
+        setHoveredCategory(category);
+        setHoveredItem(null);
+        setLastEquipped(getEquipmentById(currentEquipment[category]) ?? null);
+    };
+
+    const handleCategoryClick = (category: EquipmentCategory) => {
+        playSound("select", isSoundEnabled);
+        setSelectedCategory(category);
+        setHoveredItem(null);
+    };
+
+    const handleItemEnter = (item: EquipmentItemType) => {
+        playSound("select", isSoundEnabled);
+        setHoveredItem(item);
+    };
+
+    const handleEquip = (item: EquipmentItemType) => {
+        if (currentEquipment[item.type] === item.id) {
+            playSound("error", isSoundEnabled);
+            return;
+        }
+
+        if (item.type !== "accessory") {
+            const rowIndex = (item.type === "weapon") ? 0 : 1;
+            const nextMateria = currentMateria.map(row => [...row]);
+            nextMateria[rowIndex] = resizeMateriaRow(nextMateria[rowIndex], slotCount(item));
+            dispatch({ type: "SET_CURRENT_MATERIA", payload: nextMateria });
+        }
+
+        dispatch({ type: "SET_CURRENT_EQUIPMENT", payload: { ...currentEquipment, [item.type]: item.id } });
+        playSound("materia", isSoundEnabled);
+        setSelectedCategory(null);
+        setHoveredItem(null);
+        setLastEquipped(item);
+    };
+
+    return (
+        <>
+            <ContentBox data-label="equipHeader" className="h-[225px] absolute top-0">
+                <div className="flex items-start">
+                    <div className="w-[447px] mb-2 ml-2 shrink-0">
+                        <PartyMember memberId={1} />
+                    </div>
+                    <ul className="grow mt-2 ml-6 mr-[270px]" onMouseLeave={() => setHoveredCategory(null)}>
+                        {CATEGORIES.map(({ key, label }) => {
+                            const equipped = getEquipmentById(currentEquipment[key]);
+                            return (
+                                <li key={key} onMouseEnter={() => handleCategoryEnter(key)} onClick={() => handleCategoryClick(key)} className={`${styles.equipRow} flex mb-[26px]`} data-active={key === selectedCategory}>
+                                    <span className="w-[90px] mr-3 shrink-0">{textToSprite(label, false, "blue")}</span>
+                                    <span className="flex">{textToSprite(equipped?.name ?? "")}</span>
+                                </li>
+                            );
+                        })}
+                    </ul>
+                </div>
+            </ContentBox>
+            <ContentBox data-label="equipDescription" className="h-[79px] absolute top-[234px]"><p>{textToSprite(previewItem?.description ?? "")}</p></ContentBox>
+            <ContentBox data-label="equipSlots" className="h-[158px] absolute top-[323px]">
+                {slotItem && (
+                    <>
+                        <div className="flex items-center">
+                            <span className="w-[150px]">{textToSprite("Slot", false, "blue")}</span>
+                            <div className="grow">
+                                <MateriaSlotPreview multiSlots={slotItem.slots?.multiSlots ?? 0} singleSlots={slotItem.slots?.singleSlots ?? 0} />
+                            </div>
+                        </div>
+                        <div className="flex items-center mt-6">
+                            <span className="w-[150px]">{textToSprite("Growth", false, "blue")}</span>
+                            <span className="ml-24">{textToSprite((slotItem.slots && slotCount(slotItem) > 0) ? "Normal" : "Nothing")}</span>
+                        </div>
+                    </>
+                )}
+            </ContentBox>
+            <ContentBox data-label="equipStats" className="absolute top-[490px] bottom-0">
+                <ul>
+                    {STAT_ROWS.map(({ key, label }) => (
+                        <li key={key} className="flex items-center mb-1.5">
+                            <span className="w-[230px]">{textToSprite(label, false, "blue")}</span>
+                            <span className="w-[80px] flex justify-end">{textToSprite(String(currentStats[key]), true)}</span>
+                            {hoveredItem && (
+                                <>
+                                    <span className="mx-6">{textToSprite(">", false, "blue")}</span>
+                                    <span className="w-[80px] flex justify-end">{textToSprite(String(newStats[key]), true, (newStats[key] > currentStats[key]) ? "yellow" : (newStats[key] < currentStats[key]) ? "red" : "white")}</span>
+                                </>
+                            )}
+                        </li>
+                    ))}
+                </ul>
+            </ContentBox>
+            <ContentBox data-label="equipContentRight" className="absolute top-[323px] right-0 bottom-0">
+                <ul onMouseLeave={() => setHoveredItem(null)}>
+                    {categoryItems.map((item) => (
+                        <li key={item.id} onMouseEnter={() => handleItemEnter(item)} onClick={() => handleEquip(item)} className="mb-3">
+                            <span className={`${styles.equipmentItem} flex`}>{textToSprite(item.name)}</span>
+                        </li>
+                    ))}
+                </ul>
+            </ContentBox>
+        </>
+    );
+}
+
+export default Equip;

--- a/frontend/src/pages/Skills/SkillsContent.tsx
+++ b/frontend/src/pages/Skills/SkillsContent.tsx
@@ -8,11 +8,14 @@ import textToSprite from "../../util/textToSprite";
 import playSound from "../../util/sounds";
 import skillsJSON from "../../data/skills.json";
 import type { SkillType } from "../../context/types";
+import { getEquipmentById } from "../../util/equipment";
 
 import styles from "./SkillsContent.module.scss";
 
 function SkillsContent() {
-    const { isSoundEnabled, isCRTEnabled } = useContext();
+    const { isSoundEnabled, isCRTEnabled, currentEquipment } = useContext();
+    const weapon = getEquipmentById(currentEquipment.weapon);
+    const armor = getEquipmentById(currentEquipment.armor);
     const skillPlaceholder = {
         id: 0,
         name: "",
@@ -54,8 +57,8 @@ function SkillsContent() {
                         <PartyMember memberId={1} />
                     </div>
                     <div className="mt-9 mr-2">
-                        <EquipmentSlots type="Wpn." name="Mouse" multiSlots={3} singleSlots={2} materia={skillsJSON as SkillType[]} setSkill={setSkill} selectedMateria={selectedMateria} setSelectedMateria={setSelectedMateria} />
-                        <EquipmentSlots type="Arm." name="Keyboard" multiSlots={2} singleSlots={2} materia={skillsJSON as SkillType[]} setSkill={setSkill} selectedMateria={selectedMateria} setSelectedMateria={setSelectedMateria} />
+                        <EquipmentSlots type="Wpn." name={weapon?.name} multiSlots={weapon?.slots?.multiSlots} singleSlots={weapon?.slots?.singleSlots} materia={skillsJSON as SkillType[]} setSkill={setSkill} selectedMateria={selectedMateria} setSelectedMateria={setSelectedMateria} />
+                        <EquipmentSlots type="Arm." name={armor?.name} multiSlots={armor?.slots?.multiSlots} singleSlots={armor?.slots?.singleSlots} materia={skillsJSON as SkillType[]} setSkill={setSkill} selectedMateria={selectedMateria} setSelectedMateria={setSelectedMateria} />
                     </div>
                 </div>
             </ContentBox>

--- a/frontend/src/util/equipment.ts
+++ b/frontend/src/util/equipment.ts
@@ -1,0 +1,23 @@
+import equipmentJSON from "../data/equipment.json";
+import type { EquipmentItemType, EquipmentStats, CurrentEquipment } from "../context/types";
+
+export const getEquipmentById = (id: number | null): EquipmentItemType | undefined =>
+    (equipmentJSON as EquipmentItemType[]).find(item => item.id === id);
+
+export const slotCount = (item: EquipmentItemType): number =>
+    (item.slots?.multiSlots ?? 0) * 2 + (item.slots?.singleSlots ?? 0);
+
+export const resizeMateriaRow = (row: (number | null)[], totalSlots: number): (number | null)[] =>
+    Array.from({ length: totalSlots }, (_, i) => row[i] ?? null);
+
+export const getDerivedStats = (equipment: CurrentEquipment): Required<EquipmentStats> => {
+    const equipped = [equipment.weapon, equipment.armor, equipment.accessory].map(getEquipmentById);
+
+    return equipped.reduce((totals, item) => {
+        if (!item) return totals;
+        for (const key of Object.keys(totals) as (keyof EquipmentStats)[]) {
+            totals[key] += item.stats[key] ?? 0;
+        }
+        return totals;
+    }, { attack: 0, attackPct: 0, magicAtk: 0, defense: 0, defensePct: 0, magicDefPct: 0 });
+};


### PR DESCRIPTION
Adds a functional /equip page replicating FF7's equipment screen:

- Category rows (Wpn./Arm./Acc.), item description, materia slot/growth preview, stat comparison (yellow = increase, red = decrease) and a filtered item list
- equipment.json with dev-gear themed weapons, armor and accessories
- Equipped gear is stored in context and drives the Skills page weapon/armor names and materia slot layouts; materia rows resize when equipping gear with different slot counts
- New read-only MateriaSlotPreview component; "Equip" menu entry under Skills

🤖 Generated with [Claude Code](https://claude.com/claude-code)