### PR TITLE
Swap materia between equipment slots

### DIFF
--- a/frontend/src/pages/Skills/SkillsContent.tsx
+++ b/frontend/src/pages/Skills/SkillsContent.tsx
@@ -81,6 +81,25 @@ function SkillsContent() {
             return;
         }
 
+        if (targetSlot && (targetSlot.arrIndex !== arrIndex || targetSlot.slotIndex !== slotIndex)) {
+            // A slot was already selected; clicking a different slot swaps their
+            // contents. An empty target still swaps, emptying the source slot.
+            const nextMateria = currentMateria.map(row => [...row]);
+            const held = nextMateria[targetSlot.arrIndex][targetSlot.slotIndex] ?? null;
+            const target = nextMateria[arrIndex][slotIndex] ?? null;
+            nextMateria[targetSlot.arrIndex][targetSlot.slotIndex] = target;
+            nextMateria[arrIndex][slotIndex] = held;
+            dispatch({ type: "SET_CURRENT_MATERIA", payload: nextMateria });
+            playSound("materia", isSoundEnabled);
+            setTargetSlot(null);
+
+            // Land the cursor on the destination slot and show what now sits there
+            setPosSilently({ group: (arrIndex === 0) ? "wpnSlots" : "armSlots", index: slotIndex });
+            const skillObj = skills.find(item => item.id === held);
+            setSkill(skillObj ?? skillPlaceholder);
+            return;
+        }
+
         // FF7 flow: choose the slot first, then pick its materia from the list
         playSound("select", isSoundEnabled);
         setTargetSlot({ arrIndex, slotIndex });


### PR DESCRIPTION
On the Skills page, selecting a materia slot prompts you to pick a materia from the list. Previously, if you instead clicked a *second* slot, it just re-pointed the selection at that slot.

Now, clicking a different slot while one is already selected **swaps the two slots' contents**:

- Filled → filled: the two materia swap places.
- Filled → empty: the materia moves, leaving the source slot empty.
- Empty → filled: the materia moves back into the source slot.

After swapping, the cursor lands on the destination slot and the detail panel updates to show what now sits there. Picking from the list, holding a materia, re-clicking the same slot, and cancel all behave exactly as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)