### PR TITLE
Size the carousel in design pixels, not viewport height

### DIFF
--- a/frontend/src/pages/Projects/ImageCarousel.module.scss
+++ b/frontend/src/pages/Projects/ImageCarousel.module.scss
@@ -12,10 +12,15 @@
 .panelWrap {
     width: 70%;
     max-width: 900px;
-    // The height every stage keeps, whatever its shape. Chosen to leave the
-    // square slides the size they already were, with the head and the controls
-    // still clear of the screen's edges.
-    --stage-h: 49vh;
+    // The height every stage keeps, whatever its shape.
+    //
+    // Fixed, and in the app's own 1250x975 design pixels rather than viewport
+    // units: #root is already scaled by min(vw / 1250, vh / 975), so a `vh` here
+    // is scaled twice — once by the unit tracking the viewport and again by that
+    // transform. The modal then grew out of proportion with the menu behind it as
+    // the window or the browser's zoom changed. 440 is what 49vh came to at the
+    // size it was designed against.
+    --stage-h: 440px;
 }
 
 .panel {


### PR DESCRIPTION
The screenshot modal did not scale with the rest of the menu: on a large
display, or at a different browser zoom, it came out much larger than the
panels behind it.

### Cause

`#root` is scaled by `min(vw / 1250, vh / 975)`, so the app is a fixed
1250x975 design that a transform fits to the window. The carousel's stage
height was set in `vh`, which the viewport already governs — so it was
applied twice, once by the unit and again by the scale. At 2560x1440 the
stage measured 1254x705 design pixels where it should have been 782x440,
and rendered at 1853x1042.

Everything else in the menu is sized in design pixels and only scaled once,
which is why nothing else moved.

### Fix

`--stage-h: 440px`, which is what `49vh` came to at the size it was designed
against, so the modal is unchanged at that size and correct everywhere else.

## Testing

Measured across seven viewport sizes from 1100x700 to 2560x1440 (browser
zoom shows up as a changed CSS viewport, so this covers zooming):

- before: the stage's design-space height ran from 441 to 705 depending on
  the window
- after: a constant 782x440 design pixels, and a constant 1.342 ratio to the
  list panel behind it

Square slides still match the landscape ones in height (489x440 against
782x440), and pans still travel to exactly their own end at both extremes.
`npm run build` is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013yxFHbQB5DPVd9cRZNW3A9