### PR TITLE
Add cookieless analytics, kept out of the repository

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,12 +14,10 @@ yarn-error.log*
 # React testing
 coverage/
 
-# Environment files
+# Environment files — everything except the committed template
 .env
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env.*
+!.env.example
 
 # Python
 __pycache__/

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,0 +1,10 @@
+# Umami website ID, from the tracking code panel in the Umami dashboard.
+#
+# Copy this file to .env.production.local and paste the ID in. That file is
+# gitignored, and `vite build` reads it while `vite dev` does not — so the ID
+# never enters the repository, and running the dev server does not put localhost
+# traffic in the stats.
+#
+# Leave it empty, or skip the file entirely, and analytics are a no-op: no script
+# tag, no requests. That is what a fork gets.
+VITE_UMAMI_WEBSITE_ID=

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -3,6 +3,12 @@ import "./index.css";
 import "./font.css";
 import App from "./App.tsx";
 import { BrowserRouter } from "react-router-dom";
+import { initAnalytics } from "./util/analytics.ts";
+
+// Straight to the document rather than through a component, since it has nothing
+// to say about the tree. Route changes need no help: the tracker follows the
+// history API by itself.
+initAnalytics();
 
 createRoot(document.getElementById("root")!).render(
   <BrowserRouter>

--- a/frontend/src/util/analytics.ts
+++ b/frontend/src/util/analytics.ts
@@ -1,0 +1,31 @@
+/**
+ * Umami, injected at runtime and only when a website ID was built in.
+ *
+ * The ID comes from `.env.production.local`, which is gitignored, so a clone or
+ * a fork gets no script tag, no request and no ID — analytics are simply absent
+ * rather than broken or pointed at someone else's account. See `.env.example`.
+ *
+ * `.env.production.local` is read by `vite build` and never by `vite dev`, so
+ * working locally cannot put localhost traffic in the stats. The `PROD` guard
+ * says the same thing twice, in case the value is ever put in a file the dev
+ * server does read.
+ *
+ * Umami is cookieless, which is why there is no consent banner anywhere in the
+ * app. Anything added here that sets a cookie changes that.
+ */
+const websiteId = import.meta.env.VITE_UMAMI_WEBSITE_ID;
+
+export function initAnalytics() {
+    if (!websiteId || !import.meta.env.PROD) return;
+
+    const script = document.createElement("script");
+    script.src = "https://cloud.umami.is/script.js";
+    // The tracker reads its configuration off `document.currentScript`, so the
+    // attributes have to be set before it is appended, and it has to stay a
+    // classic script — as a module `currentScript` is null and it gives up
+    // without a word. For the same reason there is no `data-host-url`: absent,
+    // it defaults to Umami Cloud's own endpoint. `data-auto-track` is left off
+    // too, since it defaults to on and that is what tracks route changes.
+    script.setAttribute("data-website-id", websiteId);
+    document.head.appendChild(script);
+}

--- a/frontend/src/vite-env.d.ts
+++ b/frontend/src/vite-env.d.ts
@@ -1,1 +1,6 @@
 /// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+    /** Umami website ID. Optional: absent from any build but the live one. */
+    readonly VITE_UMAMI_WEBSITE_ID?: string;
+}


### PR DESCRIPTION
Traffic and referrer stats for the site, using **Umami** rather than Google
Analytics: it sets no cookies, so no consent banner is needed. GA4 would have
required one under UK PECR — banner UI on every site, and a dent in the
numbers.

### Nothing here reaches a fork

The website ID is read from `.env.production.local`, which is gitignored, and
the script is injected at runtime **only when that ID is present**. With no
ID the guard makes the branch unreachable and the bundler drops it, so a fork
has no script tag, no request, and not even the tracker's URL in the build.

`.env.production.local` rather than `.env.local` because Vite reads it for
`vite build` and never for `vite dev` — so working locally cannot put
localhost traffic in the stats. The `import.meta.env.PROD` guard repeats that
for a value put somewhere the dev server does read.

`.env.example` is committed so the setup is discoverable, and so anyone
forking has an obvious place for their own ID.

### No page-view code

The tracker patches the history API and only sends when the URL actually
changed, so react-router navigation is already recorded. Umami's docs warn
against also calling `track()` from an effect, which double-counts — so
`App.tsx` is untouched.

### Also

The `.gitignore` env block listed five specific files with no glob, leaving
`.env.production` and similar committable. Replaced with `.env`, `.env.*` and
an exception for the template.

## Testing

Verified in a browser against a production build:

- **No env file**: nothing in `dist/` matches `data-website-id` or
  `cloud.umami.is`, and no request is made.
- **With an ID**: the tag is injected as a classic script (it reads its config
  from `document.currentScript`, so a module would silently do nothing),
  `window.umami` exists, and one page view is sent on load.
- **Navigation**: one page view per route change, with the right URL, no
  duplicates.
- **Bad URL**: `/nonsense` redirects through the catch-all and records a
  single view, not two.
- `npm run build` clean.

## Before this does anything

Create `frontend/.env.production.local` with the website ID from the Umami
dashboard, then rebuild and upload. Until then the site behaves exactly as it
does today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013yxFHbQB5DPVd9cRZNW3A9