### PR TITLE
Start pages on their first row, and fade overlapping panels as one

### DIFF
--- a/frontend/src/components/MemCardSelector/MemCardSelector.tsx
+++ b/frontend/src/components/MemCardSelector/MemCardSelector.tsx
@@ -49,7 +49,10 @@ const MemCardSelector = () => {
             { id: "saves", size: saveSlotCount },
             { id: "close", size: 1 },
         ],
-        initial: null,
+        // Work starts under the cursor, as the first option. The row only draws
+        // the cursor once the card has finished loading, so it appears with the
+        // options rather than before them.
+        initial: { group: "options", index: 0 },
         fallback: isLoading ? undefined : (isListShown ? { group: "saves", index: 0 } : { group: "options", index: 0 }),
         enabled: true,
         resolveMove: (current, dir) => {

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -67,7 +67,7 @@ body.crt-effect #root:before {
   animation: panelGroupIn 0.25s ease-in 0.2s forwards;
 }
 
-.panel-group>[data-label] {
+.panel-group [data-label] {
   opacity: 1;
   animation: none;
 }

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -53,6 +53,35 @@ body.crt-effect #root:before {
   z-index: 1;
 }
 
+/* Fades a page's panels in as one group rather than each on its own.
+ *
+ * Skills and Equip overlap their panels by 10px so the two borders sit on top of
+ * one another and read as a single seam. Fading each panel separately makes them
+ * both translucent for a moment, and the border underneath shows through — the
+ * seam briefly doubles. Compositing the group first and applying the alpha to the
+ * result keeps the overlap hidden throughout.
+ *
+ * The timing matches .contentBox's own fade, so the animation is unchanged. */
+.panel-group {
+  opacity: 0;
+  animation: panelGroupIn 0.25s ease-in 0.2s forwards;
+}
+
+.panel-group>[data-label] {
+  opacity: 1;
+  animation: none;
+}
+
+@keyframes panelGroupIn {
+  from {
+    opacity: 0;
+  }
+
+  to {
+    opacity: 1;
+  }
+}
+
 /* Hide the native scrollbar on elements that use the custom FF7 <Scrollbar />. */
 .hide-scrollbar {
   scrollbar-width: none;

--- a/frontend/src/pages/Equip/Equip.tsx
+++ b/frontend/src/pages/Equip/Equip.tsx
@@ -119,7 +119,11 @@ function Equip() {
             { id: "items", size: categoryItems.length },
             { id: "close", size: 1 },
         ],
-        initial: null,
+        // The weapon row starts under the cursor so the description, slots and
+        // stats describe something on arrival rather than sitting blank. Focused,
+        // not selected: hoveredCategory drives the preview, while
+        // selectedCategory stays null, so the item list is not yet in play.
+        initial: { group: "categories", index: 0 },
         fallback: { group: "categories", index: 0 },
         enabled: true,
         resolveMove: (current, dir, { wrap }) => {

--- a/frontend/src/pages/Equip/Equip.tsx
+++ b/frontend/src/pages/Equip/Equip.tsx
@@ -200,7 +200,9 @@ function Equip() {
     }, [pos]);
 
     return (
-        <>
+        // Fades as one group: the lower panels overlap the list by 10px, and
+        // fading them separately shows the hidden border through the translucent one
+        <div className="panel-group">
             <ContentBox data-label="equipHeader" className="h-[225px] absolute top-0">
                 <div className="flex items-start">
                     <div className="w-[447px] mb-2 ml-2 shrink-0">
@@ -273,7 +275,7 @@ function Equip() {
                 </div>
                 <Scrollbar targetRef={equipListRef} />
             </ContentBox>
-        </>
+        </div>
     );
 }
 

--- a/frontend/src/pages/Landing/Landing.tsx
+++ b/frontend/src/pages/Landing/Landing.tsx
@@ -28,7 +28,9 @@ function LandingContent() {
     };
 
     return (
-        <>
+        // Fades as one group: the location and meta panels overlap the main one,
+        // and fading them separately shows the hidden borders through each other
+        <div className="panel-group">
             <ContentBox className="w-[1000px] h-[720px] m-auto absolute top-[44px]" data-label="party">
                 <PartyMember memberId={1} showProgressBars={true} healthReduction={true} />
                 <div className="flex items-center justify-center h-[340px] w-[720px] left-[53px] right-[220px] top-[294px] absolute">
@@ -58,7 +60,7 @@ function LandingContent() {
                 <span>{textToSprite(location)}</span>
                 <span className={`${styles.refresh} font-glyph`} data-sprite="reset-icon" onClick={refreshLocation}></span>
             </ContentBox>
-        </>
+        </div>
     );
 }
 

--- a/frontend/src/pages/Skills/SkillsContent.tsx
+++ b/frontend/src/pages/Skills/SkillsContent.tsx
@@ -242,7 +242,9 @@ function SkillsContent() {
     }, [pos]);
 
     return (
-        <>
+        // Fades as one group: the two lower panels overlap by 10px, and fading
+        // them separately shows the hidden border through the translucent one
+        <div className="panel-group">
             <ContentBox data-label="skillsHeader" className="h-[261px] absolute top-0">
                 <div className="flex justify-between items-end">
                     <div className="w-[447px] mb-2 ml-2">
@@ -301,7 +303,7 @@ function SkillsContent() {
                 </div>
                 <Scrollbar targetRef={materiaListRef} />
             </ContentBox>
-        </>
+        </div>
     );
 }
 

--- a/frontend/src/pages/Skills/SkillsContent.tsx
+++ b/frontend/src/pages/Skills/SkillsContent.tsx
@@ -150,8 +150,12 @@ function SkillsContent() {
 
     const { pos, focus, setPosSilently, isFocused } = useCursorNav({
         groups: [...groupCycle, { id: "close", size: 1 }],
-        initial: null,
-        fallback: { group: groupCycle[0].id, index: 0 },
+        // The first materia starts under the cursor so the panel describes
+        // something on arrival rather than sitting blank. Focused, not selected:
+        // the hook fires onFocus once without the cursor sound, and nothing is
+        // picked up for slotting until the cursor is confirmed on it.
+        initial: { group: "materia", index: 0 },
+        fallback: { group: "materia", index: 0 },
         enabled: true,
         resolveMove: (current, dir, { wrap }) => {
             // The close "X" sits at the seam of the vertical cycle, between the


### PR DESCRIPTION
Three related fixes to how pages present themselves on arrival.

### Pages start with something under the cursor

Skills, Equip and History opened with no cursor and an empty panel, so the
first thing you saw described nothing. Projects already started on its first
entry; this brings the others into line.

**Focused, not selected**, which is the distinction that matters:

- **Skills** starts on the first materia — the panel describes it, and nothing
  is held for slotting.
- **Equip** starts on the weapon row — description, slots and stats fill in,
  while `selectedCategory` stays null so the item list is not yet in play.
- **History** starts on Work. The row only draws its cursor once the memory
  card has finished loading, so it appears with the options rather than over
  the loading animation.

`useCursorNav` already had the mechanism: a non-null `initial` sets the cursor
and fires `onFocus` once, deliberately without the cursor sound. No new state
or effects. `fallback` on Skills moves with it, or a keyboard arrival would
land on the weapon slots and contradict the arrival state.

### Panels fade as one group

On Skills, Equip and Landing the seam between overlapping panels briefly
doubled on load — two parallel borders, settling to one.

Those panels overlap by 10px so their borders sit on top of one another and
read as a single seam. Every `ContentBox` fades in individually, so for the
quarter-second of the animation both are translucent and the border underneath
shows through the one covering it. Holding a pair at 50% opacity reproduces it
exactly.

`.panel-group` moves the fade up one level: the group is composited first and
the alpha applied to the result, so the overlap stays hidden the whole way in.
Timing is unchanged, and so is every frame once loaded. The rule matches any
descendant, because Landing nests its bio panel inside the main one and that
should fade with the group rather than again on top of it.

Projects needed nothing — its panels sit flush, which is why it never showed
this. Measured all five pages to confirm which were affected.

## Testing

In a browser:

- one focused row on arrival on each page, the expected one, panel populated
  from it, nothing selected
- arrows still move as before and Enter still selects from the new start
- at 50% opacity the seam matches the at-rest rendering on Skills, Equip and
  Landing
- at-rest pixels unchanged: the seam differs by 14 against a 12 baseline from
  the CRT effect animating between two captures of the same build
- `npm run build` clean

## Known remainder

The menu panel also overlaps Landing's main panel, but it is rendered by `App`
rather than by any page, so it sits outside the page's group. Including it
would mean a wrapper that persists across route changes, which would stop
pages fading in as you navigate — a worse trade for a subtler artefact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013yxFHbQB5DPVd9cRZNW3A9