### PR TITLE
Corner cursor with a picker open, settle the tabs, and group the name entry fade

### DIFF
--- a/frontend/src/pages/Config/Config.tsx
+++ b/frontend/src/pages/Config/Config.tsx
@@ -132,7 +132,15 @@ function ConfigContent() {
                             activeColorPicker={activeColorPicker}
                             setActiveColorPicker={setActiveColorPicker}
                             focusSlidersOnOpen={pickerOpenedByKeyboard}
-                            focusedCorner={!activeColorPicker ? CORNERS.find((_, index) => isFocused("corners", index)) ?? null : null}
+                            // Shown while a picker is open too: the corners stay
+                            // hoverable and clickable then, so withholding the
+                            // cursor only made them look inert. The exception is
+                            // a picker opened by keyboard, which puts a cursor on
+                            // its own sliders — two cursors at once reads worse
+                            // than none.
+                            focusedCorner={(activeColorPicker && pickerOpenedByKeyboard)
+                                ? null
+                                : CORNERS.find((_, index) => isFocused("corners", index)) ?? null}
                             onCornerEnter={(corner) => focus({ group: "corners", index: CORNERS.indexOf(corner) })}
                             onCornerClick={(corner) => openColorPicker(corner, false)}
                         />

--- a/frontend/src/pages/NameEntry/NameEntry.tsx
+++ b/frontend/src/pages/NameEntry/NameEntry.tsx
@@ -155,7 +155,9 @@ function NameEntry() {
     });
 
     return (
-        <>
+        // Fades as one group: the controls panel overlaps the keyboard, and
+        // fading them separately shows the hidden border through the translucent one
+        <div className="panel-group">
             <div className="relative h-[84px] mb-[10px]">
                 <ContentBox data-label="nameHeader" className="h-full absolute top-0 left-0 right-0">
                     {textToSprite("Please enter a name.")}
@@ -225,7 +227,7 @@ function NameEntry() {
                     ))}
                 </div>
             </div>
-        </>
+        </div>
     );
 }
 

--- a/frontend/src/pages/Projects/Projects.tsx
+++ b/frontend/src/pages/Projects/Projects.tsx
@@ -56,6 +56,11 @@ const wrap = (text: string, max: number): string[] => {
     return lines;
 };
 
+/** How long hover is ignored on the tab row after arriving on the page.
+ *  The panels fade in over ~450ms, and crossing the row on the way to the list
+ *  during that time should not switch tab. */
+const TAB_SETTLE_MS = 600;
+
 const TABS = [
     { key: "projects", label: "Projects" },
     { key: "websites", label: "Websites" },
@@ -192,6 +197,7 @@ function ProjectsContent() {
     const [selected, setSelected] = useState<Entry | null>(null);
     const [showImages, setShowImages] = useState(false);
     const [hasScrollbar, setHasScrollbar] = useState(false);
+    const [tabsSettled, setTabsSettled] = useState(false);
     const anchorRefs = useRef<(HTMLAnchorElement | null)[]>([]);
     const projectListRef = useRef<HTMLDivElement>(null);
     const projectItemRefs = useRef<(HTMLLIElement | null)[]>([]);
@@ -288,6 +294,14 @@ function ProjectsContent() {
 
     useEffect(() => () => closeNav.setFocus(false), []);
 
+    // Hover switches tab with no click needed, which is easy to trigger by
+    // accident while the page is still settling and the pointer crosses the row
+    // on its way somewhere else. Clicking a tab still works straight away.
+    useEffect(() => {
+        const timer = setTimeout(() => setTabsSettled(true), TAB_SETTLE_MS);
+        return () => clearTimeout(timer);
+    }, []);
+
     // Keep the keyboard-focused project on screen as the cursor moves.
     useEffect(() => {
         if (pos?.group === "items") {
@@ -308,7 +322,7 @@ function ProjectsContent() {
                             className={styles.tab}
                             data-focused={isFocused("tabs", index)}
                             data-active={key === tab}
-                            onPointerEnter={(event) => { if (event.pointerType === "mouse" && isPointerMoving()) selectTab(key); }}
+                            onPointerEnter={(event) => { if (tabsSettled && event.pointerType === "mouse" && isPointerMoving()) selectTab(key); }}
                             onClick={() => selectTab(key)}
                         >
                             {textToSprite(label)}


### PR DESCRIPTION
Three small annoyances.

### Colour picker corners kept their cursor hidden

With a picker open, the four window-colour corners showed no hover cursor, so
they looked inert — even though hovering and clicking still worked. The
suppression was explicit: `focusedCorner` was forced to `null` whenever
`activeColorPicker` was set. The corner buttons sit above the dismiss overlay,
so events were always reaching them; only the feedback was missing.

The cursor is shown again, with one exception: a picker opened **by keyboard**
puts a cursor on its own sliders, and showing a second one on the corners reads
worse than showing none. Caught that by testing the keyboard flow after the
first fix, which did produce two cursors.

### Tabs no longer switch while the page is settling

Hovering a tab on Projects switches to it with no click, which is easy to
trigger by accident while the page is still fading in and the pointer crosses
the row on its way to the list. Hover is ignored for `TAB_SETTLE_MS` (600ms)
after arriving, covering the ~450ms fade. Clicking still works straight away,
since that is deliberate.

### Name entry fades as one group

The same doubled seam fixed on Skills, Equip and Landing: the controls panel
overlaps the keyboard by 41px, so while each panel fades in on its own the
border underneath shows through the translucent one. `.panel-group` again.

That is now every page with overlapping panels. Projects needs none of it —
its panels sit flush.

## Testing

In a browser:

- with a picker open, hovering another corner now sets `data-focused` on it,
  and the active corner keeps its highlight
- opening the picker by keyboard leaves exactly one cursor on screen
- sweeping the pointer across the Websites tab 150ms after load leaves the tab
  on Projects; the same sweep after settling switches to Websites
- name entry at 50% opacity shows a single border at the seam, matching the
  at-rest rendering, and the page lays out unchanged
- `npm run build` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013yxFHbQB5DPVd9cRZNW3A9