### PR TITLE
Misc fixes: name entry keyboard, mobile audio, and a set of mobile layout bugs

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -5,6 +5,10 @@
   <meta charset="UTF-8" />
   <link rel="icon" type="image/svg+xml" href="/favicon.png" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
+  <!-- Tints the browser's own chrome to match the page. Firefox for Android and
+       Chrome honour this; Safari on iOS takes its colour from the page itself,
+       which is already black. -->
+  <meta name="theme-color" content="#000000">
   <meta name="description"
     content="I'm a Senior Web Developer based in Gloucester, UK. Welcome to my personal sandbox. I plan to add an ever-growing collection of small technical projects here, mostly built with PS1 aesthetics in mind.">
   <title>Jamie Pates | Personal Sandbox</title>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -34,6 +34,23 @@ import NameEntry from "./pages/NameEntry/NameEntry";
 const DESIGN_WIDTH = 1200;
 const DESIGN_HEIGHT = 975;
 
+/**
+ * A phone gets a shorter canvas. The stage is 825 tall and sits in 975, so 150px
+ * of the height is margin that exists to give a desktop window some air. On a
+ * landscape phone that margin is most of the screen, and the menu ends up tiny
+ * with wide empty bands above and below.
+ *
+ * Only phone-sized viewports, deliberately: desktop is limited by its height, so
+ * shortening the canvas there would scale the whole app up and the user is happy
+ * with how it looks. "Phone" is the shorter side, which catches both
+ * orientations and leaves tablets and every desktop window alone.
+ */
+const COMPACT_MAX_SIDE = 500;
+const COMPACT_DESIGN_HEIGHT = 880;
+
+const canvasHeight = (width: number, height: number) =>
+    Math.min(width, height) < COMPACT_MAX_SIDE ? COMPACT_DESIGN_HEIGHT : DESIGN_HEIGHT;
+
 function App() {
   const [isLoaded, setIsLoaded] = useState(false);
 
@@ -50,9 +67,19 @@ function App() {
         const viewportHeight = document.documentElement.clientHeight;
         const scale = Math.min(
           viewportWidth / DESIGN_WIDTH,
-          viewportHeight / DESIGN_HEIGHT
+          viewportHeight / canvasHeight(viewportWidth, viewportHeight)
         );
-        const offsetY = Math.max(0, (viewportHeight - DESIGN_HEIGHT * scale) / 2);
+        /**
+         * Centres the element's own box, measured rather than assumed, and is
+         * allowed to go negative so a box taller than the window overhangs
+         * evenly instead of hanging off the bottom. offsetHeight is layout
+         * pixels, so the transform does not feed back into it.
+         *
+         * This used to centre the design canvas and clamp at 0, which is the
+         * same answer whenever the canvas and the box are the same height —
+         * every case before the compact canvas existed.
+         */
+        const offsetY = (viewportHeight - app.offsetHeight * scale) / 2;
         app.style.transform = `translateY(${offsetY}px) scale(${scale})`;
       }
     }

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -12,6 +12,28 @@ import Config from "./pages/Config/Config";
 import Resume from "./pages/Resume/Resume";
 import NameEntry from "./pages/NameEntry/NameEntry";
 
+/**
+ * The canvas the app is scaled to fit.
+ *
+ * The height is the design height. The width only has to cover the 1100px stage
+ * plus the widest thing hung outside it. Cursors and the close button overhang:
+ * measured at 1440x900 and on a phone, the Projects tab cursor reaches ~40px
+ * past the left edge and the close button ~21px past the right. The canvas is
+ * centred on the stage, so it needs twice the worst side — 1100 + 2x40 = 1180 —
+ * and 1200 leaves a margin on top of that.
+ *
+ * It used to be 1250. The extra was never reached by anything, and on a phone,
+ * where the width is the limiting term, it letterboxed dead space onto both
+ * sides for nothing. Desktop is unaffected: an ordinary window is limited by its
+ * height, so min() still picks the height term and the scale is identical.
+ *
+ * If a page grows a wider overhang, this has to grow with it or the overhang
+ * clips at the screen edge. Check with a screenshot on the narrowest phone, not
+ * by eye on a desktop — desktop has hundreds of pixels of slack and hides it.
+ */
+const DESIGN_WIDTH = 1200;
+const DESIGN_HEIGHT = 975;
+
 function App() {
   const [isLoaded, setIsLoaded] = useState(false);
 
@@ -27,10 +49,10 @@ function App() {
         const viewportWidth = document.documentElement.clientWidth;
         const viewportHeight = document.documentElement.clientHeight;
         const scale = Math.min(
-          viewportWidth / 1250,
-          viewportHeight / 975
+          viewportWidth / DESIGN_WIDTH,
+          viewportHeight / DESIGN_HEIGHT
         );
-        const offsetY = Math.max(0, (viewportHeight - 975 * scale) / 2);
+        const offsetY = Math.max(0, (viewportHeight - DESIGN_HEIGHT * scale) / 2);
         app.style.transform = `translateY(${offsetY}px) scale(${scale})`;
       }
     }

--- a/frontend/src/components/HistorySave/HistorySave.tsx
+++ b/frontend/src/components/HistorySave/HistorySave.tsx
@@ -12,6 +12,8 @@ interface historySaveProps {
     historyType: string;
     focused?: boolean;
     onEnter?: () => void;
+    /** Slot index, so a stationary pointer can be matched to a row */
+    "data-slot"?: number;
 };
 
 const HistorySave: React.FC<historySaveProps> = ({ historyItem, historyType, focused = false, onEnter, ...props }) => {

--- a/frontend/src/components/MemCardLoadingBar/MemCardLoadingBar.tsx
+++ b/frontend/src/components/MemCardLoadingBar/MemCardLoadingBar.tsx
@@ -4,7 +4,6 @@ import ContentBox from "../ContentBox/ContentBox";
 import playSound from "../../util/sounds";
 import { useContext } from "../../context/context";
 import { useEffect } from "react";
-import textToSprite from "../../util/textToSprite";
 
 interface MemCardLoadingBarProps {
     memoryCardProgress: number,
@@ -29,9 +28,6 @@ const MemCardLoadingBar: React.FC<MemCardLoadingBarProps> = ({ memoryCardProgres
 
     return (
         <>
-            <div className="relative h-[84px] mb-[10px]">
-                <ContentBox data-label="MemCardHeader" className="h-full absolute top-0 left-0 right-0">{textToSprite("Checking Save Data File.")}</ContentBox>
-            </div>
             <ContentBox data-label="memCardLoadingBar" className={`w-[27rem] h-[6rem] absolute z-2 left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2`}>
                 <div className={`${styles.memCardLoadingBar} h-[3rem]`} style={{ width: memoryCardProgress + "%" }} data-progress={memoryCardProgress} />
             </ContentBox>

--- a/frontend/src/components/MemCardSelector/MemCardSelector.tsx
+++ b/frontend/src/components/MemCardSelector/MemCardSelector.tsx
@@ -18,6 +18,13 @@ import type { HistoryType } from "../../context/types";
 const MIN_SAVE_SLOTS = 3;
 const OPTIONS = ["work", "education"];
 
+/**
+ * How long a ContentBox takes to fade in — 0.25s, after a 0.2s delay. The save
+ * rows' cursor is a ::before on the row rather than on the box, so it does not
+ * fade with it and would otherwise sit over an empty panel for that beat.
+ */
+const CONTENT_FADE_MS = 450;
+
 const MemCardSelector = () => {
     const { isSoundEnabled } = useContext();
     const navigate = useNavigate();
@@ -25,6 +32,7 @@ const MemCardSelector = () => {
     const [optionSelected, setOptionSelected] = useState(false);
     const [selectedHistoryType, setSelectedHistoryType] = useState("work");
     const [memoryCardProgress, setMemoryCardProgress] = useState(0);
+    const [savesRevealed, setSavesRevealed] = useState(false);
 
     const isLoading = optionSelected && memoryCardProgress <= 100;
     const isListShown = optionSelected && memoryCardProgress > 100;
@@ -125,6 +133,17 @@ const MemCardSelector = () => {
 
     useEffect(() => () => closeNav.setFocus(false), []);
 
+    // Hold the cursor back until the save rows have finished fading in, the way
+    // the option rows already wait on memoryCardLoaded
+    useEffect(() => {
+        if (!isListShown) {
+            setSavesRevealed(false);
+            return;
+        }
+        const timer = setTimeout(() => setSavesRevealed(true), CONTENT_FADE_MS);
+        return () => clearTimeout(timer);
+    }, [isListShown]);
+
     // If keyboard navigation was in progress, move the cursor onto the save
     // list once the memory card has loaded it (mouse flows keep no cursor)
     useEffect(() => {
@@ -133,11 +152,21 @@ const MemCardSelector = () => {
         }
     }, [isListShown]); // eslint-disable-line react-hooks/exhaustive-deps
 
+    const headerText = isListShown
+        ? "Select a file."
+        : isLoading ? "Checking Save Data File." : "Select a Save Data File.";
+
     return (
         <>
-            {!optionSelected && <div className="relative h-[84px] mb-[10px]">
-                <ContentBox data-label="MemCardHeader" className="h-full absolute top-0 left-0 right-0">{textToSprite("Select a Save Data File.")}</ContentBox>
-            </div>}
+            {/* One header box across all three states. Each state used to render
+                its own, so selecting an option unmounted the previous box and
+                mounted a new one — the bar faded out and back in at every step
+                rather than just changing its text. */}
+            <div className="relative h-[84px] mb-[10px]">
+                <ContentBox data-label="MemCardHeader" className="h-full absolute top-0 left-0 right-0">{textToSprite(headerText)}</ContentBox>
+                {isListShown && <ContentBox data-label="historyFileLabel" className="h-full w-[225px] absolute top-0 right-[280px] flex">{textToSprite("FILE", false, "yellow")}{textToSprite((selectedHistoryType !== "education") ? " 01" : " 02")}</ContentBox>}
+            </div>
+
             {!optionSelected && <ContentBox data-label="memCardSelector" className="absolute z-1 left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2">
                 <ul className={`${styles.historyOptions} flex flex-col items-center gap-1`}>
                     {OPTIONS.map((option, index) => (
@@ -149,7 +178,7 @@ const MemCardSelector = () => {
             </ContentBox>}
 
             {isLoading && <MemCardLoadingBar memoryCardProgress={memoryCardProgress} setMemoryCardProgress={setMemoryCardProgress} />}
-            {isListShown && <History historyType={selectedHistoryType} focusedIndex={pos?.group === "saves" ? pos.index : null} onItemEnter={(index) => focus({ group: "saves", index })} onEmptyClick={() => playSound("error", isSoundEnabled)} />}
+            {isListShown && <History historyType={selectedHistoryType} focusedIndex={savesRevealed && pos?.group === "saves" ? pos.index : null} onItemEnter={(index) => focus({ group: "saves", index })} onEmptyClick={() => playSound("error", isSoundEnabled)} />}
         </>
     );
 };

--- a/frontend/src/components/MemCardSelector/MemCardSelector.tsx
+++ b/frontend/src/components/MemCardSelector/MemCardSelector.tsx
@@ -7,10 +7,11 @@ import ContentBox from "../ContentBox/ContentBox";
 import textToSprite from "../../util/textToSprite";
 import playSound from "../../util/sounds";
 import { useContext } from "../../context/context";
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { useCursorNav, markKeyboardNavigation } from "../../hooks/useCursorNav";
 import { closeNav } from "../../hooks/closeNav";
+import { elementUnderPointer } from "../../util/pointerActivity";
 import educationJSON from "../../data/education.json";
 import historyJSON from "../../data/history.json";
 import type { HistoryType } from "../../context/types";
@@ -40,16 +41,38 @@ const MemCardSelector = () => {
     const historyItems = (selectedHistoryType === "education") ? (educationJSON as HistoryType[]) : (historyJSON as HistoryType[]);
     const saveSlotCount = Math.max(MIN_SAVE_SLOTS, historyItems.length);
 
-    const onClickHandler = (historyType: string) => {
+    // Whether the option was picked with the mouse. A keyboard pick should land
+    // on the first save whatever the mouse happens to be resting over.
+    const pickedByMouse = useRef(false);
+
+    const onClickHandler = (historyType: string, viaMouse = false) => {
         if (!memoryCardLoaded) {
             playSound("error", isSoundEnabled);
             return;
         }
+        pickedByMouse.current = viaMouse;
         playSound("select", isSoundEnabled);
         setOptionSelected(true);
         setSelectedHistoryType(historyType)
 
     }
+
+    /**
+     * Which save row the pointer is already sitting on, if any.
+     *
+     * The list opens centred on where the options were, so the pointer is very
+     * often inside a row the moment it appears — usually the second. No
+     * mouseenter fires for that, because the content moved rather than the
+     * mouse, so the cursor sat on the first row while a click would have opened
+     * the second. Reading the pointer's position directly is the only way to
+     * reconcile the two without making the user jiggle the mouse.
+     */
+    const slotUnderPointer = (): number | null => {
+        if (!pickedByMouse.current) return null;
+        const slot = elementUnderPointer()?.closest("[data-slot]");
+        const index = slot ? Number(slot.getAttribute("data-slot")) : NaN;
+        return Number.isInteger(index) ? index : null;
+    };
 
     const { pos, focus, setPosSilently, isFocused } = useCursorNav({
         groups: [
@@ -148,7 +171,7 @@ const MemCardSelector = () => {
     // list once the memory card has loaded it (mouse flows keep no cursor)
     useEffect(() => {
         if (isListShown && pos && pos.group !== "saves") {
-            setPosSilently({ group: "saves", index: 0 });
+            setPosSilently({ group: "saves", index: slotUnderPointer() ?? 0 });
         }
     }, [isListShown]); // eslint-disable-line react-hooks/exhaustive-deps
 
@@ -170,7 +193,7 @@ const MemCardSelector = () => {
             {!optionSelected && <ContentBox data-label="memCardSelector" className="absolute z-1 left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2">
                 <ul className={`${styles.historyOptions} flex flex-col items-center gap-1`}>
                     {OPTIONS.map((option, index) => (
-                        <li key={option} className="w-full flex justify-center mr-1" data-focused={isFocused("options", index) && memoryCardLoaded} onMouseEnter={() => focus({ group: "options", index })} onClick={() => { onClickHandler(option) }}>
+                        <li key={option} className="w-full flex justify-center mr-1" data-focused={isFocused("options", index) && memoryCardLoaded} onMouseEnter={() => focus({ group: "options", index })} onClick={() => { onClickHandler(option, true) }}>
                             <button>{textToSprite(option.charAt(0).toUpperCase() + option.slice(1), undefined, memoryCardLoaded ? "white" : "grey")}</button>
                         </li>
                     ))}

--- a/frontend/src/components/Menu/Menu.tsx
+++ b/frontend/src/components/Menu/Menu.tsx
@@ -121,8 +121,15 @@ const Menu = () => {
         playSound("back", isSoundEnabled);
     }
 
-    const handleMouseEnter = (menuItem: MenuItem) => {
-        if (!isLanding) return;
+    /**
+     * Hover-to-focus, mouse only. A tap on a touch screen synthesises a
+     * mouseenter as well as the click, so both the hover's cursor sound and the
+     * click's select sound fired for one finger — two copies of the same clip a
+     * few milliseconds apart. pointerType tells the two inputs apart; the same
+     * guard is already on the Projects and Equip lists.
+     */
+    const handlePointerEnter = (event: React.PointerEvent, menuItem: MenuItem) => {
+        if (!isLanding || event.pointerType !== "mouse") return;
         focus({ group: "menu", index: navItems.indexOf(menuItem) });
     }
 
@@ -137,7 +144,7 @@ const Menu = () => {
 
         if (menuItem.path) {
             return (
-                <a className="flex w-100" title={menuItem.title || menuItem.name} href={menuItem.path} target="_blank" data-focused={focused} onClick={() => { playSound("select", isSoundEnabled) }} onMouseEnter={() => handleMouseEnter(menuItem)}>
+                <a className="flex w-100" title={menuItem.title || menuItem.name} href={menuItem.path} target="_blank" data-focused={focused} onClick={() => { playSound("select", isSoundEnabled) }} onPointerEnter={(event) => handlePointerEnter(event, menuItem)}>
                     {textToSprite(menuItem.name)}
                     <span className="font-glyph ml-2" data-sprite="external-link-icon"></span>
                 </a>
@@ -146,8 +153,8 @@ const Menu = () => {
 
         return (
             <>
-                <Link to={`/${menuItem.id}`} className={`${(location.pathname === `/${menuItem.id}`) ? styles.active : ""} w-100`} data-focused={focused && isLanding}><span onClick={() => handleOnClick()} onMouseEnter={() => handleMouseEnter(menuItem)}>{textToSprite(menuItem.name)}</span></Link>
-                {!isLanding && <Link to={"/"} data-label="close" data-focused={closeFocused} onClick={handleClose} onMouseEnter={() => playSound("select", isSoundEnabled)}><ContentBox className="absolute" data-label="close" >{textToSprite("X")}</ContentBox></Link>}
+                <Link to={`/${menuItem.id}`} className={`${(location.pathname === `/${menuItem.id}`) ? styles.active : ""} w-100`} data-focused={focused && isLanding}><span onClick={() => handleOnClick()} onPointerEnter={(event) => handlePointerEnter(event, menuItem)}>{textToSprite(menuItem.name)}</span></Link>
+                {!isLanding && <Link to={"/"} data-label="close" data-focused={closeFocused} onClick={handleClose} onPointerEnter={(event) => { if (event.pointerType === "mouse") playSound("select", isSoundEnabled); }}><ContentBox className="absolute" data-label="close" >{textToSprite("X")}</ContentBox></Link>}
             </>
         )
     }

--- a/frontend/src/components/Scrollbar/Scrollbar.tsx
+++ b/frontend/src/components/Scrollbar/Scrollbar.tsx
@@ -47,7 +47,16 @@ const Scrollbar: React.FC<ScrollbarProps> = ({ targetRef, onVisibleChange }) => 
                 return;
             }
             const height = Math.max(MIN_THUMB, Math.round(trackH * THUMB_FRACTION));
-            const top = Math.round((trackH - height) * (scrollTop / scrollable));
+            /**
+             * Clamped because scrollTop is not bounded on every platform. iOS
+             * rubber-bands past the ends, reporting a negative scrollTop at the
+             * top and more than the scrollable height at the bottom, which sent
+             * the thumb sliding out of its track and back again as the finger
+             * lifted. Pinning it to the ends instead reads as the list stretching
+             * under a thumb that has simply run out of travel.
+             */
+            const progress = Math.min(1, Math.max(0, scrollTop / scrollable));
+            const top = Math.round((trackH - height) * progress);
             setThumb({ visible: true, height, top });
         };
 

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,5 +1,25 @@
 @import "tailwindcss";
 
+/* The black has to be on html, not only on body.
+ *
+ * iOS insets the layout viewport from the notch and the home indicator, and in
+ * landscape that leaves a band down each side of the screen. Those bands are
+ * outside body, so they are painted from the root element — which had no
+ * background and so came out white. */
+html {
+  background: #000;
+  /* Declares the page as dark, so browser-drawn UI — form controls, scrollbars,
+   * and the address bar on anything that does not read theme-color — picks its
+   * dark variant instead of assuming a white page. */
+  color-scheme: dark;
+  /* body's overflow only hides its own; the document itself stays scrollable,
+   * and on a short viewport the layout box is taller than the window. Nothing
+   * here wants the document to scroll — every page scrolls inside its own
+   * panel — so this stops a stray swipe shifting the whole app. It does not
+   * stop programmatic scrolling: see the note on Skills in CLAUDE.md. */
+  overflow: hidden;
+}
+
 body {
   background: #000;
   color: #fff;

--- a/frontend/src/pages/Equip/Equip.tsx
+++ b/frontend/src/pages/Equip/Equip.tsx
@@ -7,6 +7,7 @@ import PartyMember from "../../components/PartyMember/PartyMember";
 import MateriaSlotPreview from "../../components/MateriaSlotPreview/MateriaSlotPreview";
 import Scrollbar from "../../components/Scrollbar/Scrollbar";
 import { isPointerMoving } from "../../util/pointerActivity";
+import { scrollIntoList } from "../../util/scrollIntoList";
 import textToSprite from "../../util/textToSprite";
 import playSound from "../../util/sounds";
 import { getEquipmentById, getDerivedStats, slotCount, resizeMateriaRow } from "../../util/equipment";
@@ -195,7 +196,7 @@ function Equip() {
     // Keep the keyboard-focused equipment row on screen as the cursor moves.
     useEffect(() => {
         if (pos?.group === "items") {
-            equipItemRefs.current[pos.index]?.scrollIntoView({ block: "nearest" });
+            scrollIntoList(equipItemRefs.current[pos.index]);
         }
     }, [pos]);
 

--- a/frontend/src/pages/History/History.tsx
+++ b/frontend/src/pages/History/History.tsx
@@ -23,10 +23,6 @@ const HistoryContent: React.FC<HistoryProps> = ({ historyType, focusedIndex = nu
 
     return (
         <>
-            <div className="relative h-[84px] mb-[10px]">
-                <ContentBox data-label="historyHeader" className="h-full absolute top-0 left-0 right-0">{textToSprite("Select a file.")}</ContentBox>
-                <ContentBox data-label="historyFileLabel" className="h-full w-[225px] absolute top-0 right-[280px] flex">{textToSprite("FILE", false, "yellow")}{textToSprite((historyType !== "education") ? " 01" : " 02")}</ContentBox>
-            </div>
             {history.map((item, index) => (
                 <HistorySave key={item.id} historyItem={item} historyType={historyType} focused={focusedIndex === index} onEnter={() => onItemEnter?.(index)} />
             ))}

--- a/frontend/src/pages/History/History.tsx
+++ b/frontend/src/pages/History/History.tsx
@@ -24,13 +24,13 @@ const HistoryContent: React.FC<HistoryProps> = ({ historyType, focusedIndex = nu
     return (
         <>
             {history.map((item, index) => (
-                <HistorySave key={item.id} historyItem={item} historyType={historyType} focused={focusedIndex === index} onEnter={() => onItemEnter?.(index)} />
+                <HistorySave key={item.id} historyItem={item} historyType={historyType} focused={focusedIndex === index} onEnter={() => onItemEnter?.(index)} data-slot={index} />
             ))}
 
             {Array.from({ length: placeholdersNeeded }).map((_, index) => {
                 const slotIndex = history.length + index;
                 return (
-                    <div key={index} className={saveStyles.historySave} data-focused={focusedIndex === slotIndex} onMouseEnter={() => onItemEnter?.(slotIndex)} onClick={() => onEmptyClick?.()}>
+                    <div key={index} className={saveStyles.historySave} data-slot={slotIndex} data-focused={focusedIndex === slotIndex} onMouseEnter={() => onItemEnter?.(slotIndex)} onClick={() => onEmptyClick?.()}>
                         <ContentBox data-label="historySave" className="h-[235px] relative flex items-center"><span className="pl-32">{textToSprite("EMPTY", false, "yellow")}</span></ContentBox>
                     </div>
                 );

--- a/frontend/src/pages/NameEntry/NameEntry.tsx
+++ b/frontend/src/pages/NameEntry/NameEntry.tsx
@@ -32,6 +32,14 @@ const ROWS = KEY_ROWS.length;
 
 const CONTROLS = ["Space", "Delete", "Select", "Default"];
 
+/**
+ * Everything the real keyboard can type: the glyphs on the on-screen keyboard,
+ * plus the space that the Space control inserts. Anything outside this set has
+ * no glyph in the sprite font, so it does nothing at all rather than being
+ * silently dropped into the name.
+ */
+const TYPEABLE = new Set<string>([...KEY_ROWS.flat().filter((ch): ch is string => ch !== null), " "]);
+
 const cellAt = (row: number, col: number): string | null =>
     (row >= 0 && row < ROWS && col >= 0 && col < COLS) ? KEY_ROWS[row][col] : null;
 
@@ -76,6 +84,45 @@ function NameEntry() {
         playSound("back", isSoundEnabled);
         setName(name.slice(0, -1));
     };
+
+    /**
+     * Typing on the real keyboard, alongside the on-screen one. Held in a ref
+     * and reassigned each render so the listener is registered once but always
+     * sees the current name.
+     */
+    const typeKey = useRef<(event: KeyboardEvent) => void>(() => { });
+    typeKey.current = (event: KeyboardEvent) => {
+        // Leave browser and OS shortcuts alone
+        if (event.metaKey || event.ctrlKey || event.altKey) return;
+
+        if (event.key === "Backspace") {
+            event.preventDefault();
+            event.stopPropagation();
+            deleteChar();
+            return;
+        }
+
+        // Anything with a longer name is a control key — the arrows, Enter,
+        // Escape — and belongs to the menu cursor, so it is left to pass through
+        if (event.key.length !== 1) return;
+
+        event.preventDefault();
+        // Consumed before useCursorNav can see it. Space is "cancel" there, so
+        // typing one would otherwise leave the page instead of adding a space.
+        event.stopPropagation();
+
+        // An unsupported character has no glyph in the sprite font, so it does
+        // nothing rather than being dropped into the name unseen
+        if (TYPEABLE.has(event.key)) appendChar(event.key);
+    };
+
+    useEffect(() => {
+        const onKeyDown = (event: KeyboardEvent) => typeKey.current(event);
+        // Capture phase: useCursorNav listens on window too, and a key this page
+        // claims has to be taken before that listener runs
+        window.addEventListener("keydown", onKeyDown, true);
+        return () => window.removeEventListener("keydown", onKeyDown, true);
+    }, []);
 
     const restoreDefault = () => {
         playSound("back", isSoundEnabled);

--- a/frontend/src/pages/Projects/ImageCarousel.module.scss
+++ b/frontend/src/pages/Projects/ImageCarousel.module.scss
@@ -1,7 +1,19 @@
 // Screenshot carousel, sitting over the menu rather than inside a panel of it
 .overlay {
     position: fixed;
-    inset: 0;
+    /**
+     * Not `inset: 0`. #root carries a transform, which makes it the containing
+     * block for fixed children — so `0` is #root's box, not the viewport, and
+     * #root is only as wide as the 1100px stage. Anything hung outside that box
+     * stayed lit: the close button sits at `right: -43px`, and on a phone a
+     * third of it was left uncovered above the dimmed page.
+     *
+     * The overshoot is in design pixels, not vw/vh, because #root is already
+     * scaled and viewport units would be applied twice. 1000 is far more than
+     * the widest overhang and costs nothing — the element only paints a tint,
+     * and body has overflow hidden.
+     */
+    inset: -1000px;
     z-index: 40;
     display: flex;
     align-items: center;

--- a/frontend/src/pages/Projects/Projects.tsx
+++ b/frontend/src/pages/Projects/Projects.tsx
@@ -213,7 +213,11 @@ function ProjectsContent() {
         ],
         initial: null,
         fallback: { group: "tabs", index: 0 },
-        enabled: true,
+        // Frozen while the captures are open. The arrow keys belong to the
+        // carousel then, and moving the selection underneath it left the
+        // carousel showing image 4 of an entry that only has 2 — the same
+        // reason the Config page disables this while a colour picker is up.
+        enabled: !showImages,
         resolveMove: (pos, dir) => {
             // The tab row is a row, so it is the one place left and right mean
             // anything. Everywhere else they are ignored, as before.
@@ -451,7 +455,10 @@ function ProjectsContent() {
             </ContentBox>
 
             {showImages && selected && (
-                <ImageCarousel entry={selected} onClose={() => setShowImages(false)} />
+                // Keyed by entry so a different project always gets a fresh
+                // carousel starting at its first image, rather than inheriting
+                // an index the new entry may not have
+                <ImageCarousel key={selected.key} entry={selected} onClose={() => setShowImages(false)} />
             )}
         </>
     );

--- a/frontend/src/pages/Projects/Projects.tsx
+++ b/frontend/src/pages/Projects/Projects.tsx
@@ -6,6 +6,7 @@ import ContentBox from "../../components/ContentBox/ContentBox";
 import ImageCarousel, { type Shot } from "./ImageCarousel";
 import Scrollbar from "../../components/Scrollbar/Scrollbar";
 import { isPointerMoving } from "../../util/pointerActivity";
+import { scrollIntoList } from "../../util/scrollIntoList";
 import textToSprite from "../../util/textToSprite";
 import playSound from "../../util/sounds";
 import { useCursorNav, markKeyboardNavigation } from "../../hooks/useCursorNav";
@@ -309,7 +310,7 @@ function ProjectsContent() {
     // Keep the keyboard-focused project on screen as the cursor moves.
     useEffect(() => {
         if (pos?.group === "items") {
-            projectItemRefs.current[pos.index]?.scrollIntoView({ block: "nearest" });
+            scrollIntoList(projectItemRefs.current[pos.index]);
         }
     }, [pos]);
 

--- a/frontend/src/pages/Skills/SkillsContent.tsx
+++ b/frontend/src/pages/Skills/SkillsContent.tsx
@@ -7,6 +7,7 @@ import PartyMember from "../../components/PartyMember/PartyMember";
 import EquipmentSlots from "../../components/EquipmentSlots/EquipmentSlots";
 import Scrollbar from "../../components/Scrollbar/Scrollbar";
 import { isPointerMoving } from "../../util/pointerActivity";
+import { scrollIntoList } from "../../util/scrollIntoList";
 import textToSprite from "../../util/textToSprite";
 import playSound from "../../util/sounds";
 import skillsJSON from "../../data/skills.json";
@@ -237,7 +238,7 @@ function SkillsContent() {
     // visible rows; snap alignment lands it on a whole-row boundary.
     useEffect(() => {
         if (pos?.group === "materia") {
-            materiaItemRefs.current[pos.index]?.scrollIntoView({ block: "nearest" });
+            scrollIntoList(materiaItemRefs.current[pos.index]);
         }
     }, [pos]);
 

--- a/frontend/src/util/pointerActivity.ts
+++ b/frontend/src/util/pointerActivity.ts
@@ -3,11 +3,20 @@
 // and slides a new item under an otherwise-stationary cursor, which fires a
 // spurious mouseenter and would otherwise hijack the selection.
 let movingUntil = 0;
+// Where the pointer last was, so a surface appearing underneath a stationary
+// pointer can work out what it opened under. No mouseenter fires in that case —
+// the content moved, not the mouse — so there is nothing else to go on.
+let lastX: number | null = null;
+let lastY: number | null = null;
 
 if (typeof window !== "undefined") {
     window.addEventListener(
         "mousemove",
-        () => { movingUntil = performance.now() + 100; },
+        (event) => {
+            movingUntil = performance.now() + 100;
+            lastX = event.clientX;
+            lastY = event.clientY;
+        },
         { passive: true },
     );
     // Any scroll means items moved under the pointer, not the pointer over items.
@@ -19,3 +28,11 @@ if (typeof window !== "undefined") {
 }
 
 export const isPointerMoving = () => performance.now() < movingUntil;
+
+/**
+ * The element currently under the pointer, or null if the mouse has not moved
+ * yet this session. elementFromPoint takes viewport coordinates, so it copes
+ * with #root's transform on its own.
+ */
+export const elementUnderPointer = (): Element | null =>
+    (lastX === null || lastY === null) ? null : document.elementFromPoint(lastX, lastY);

--- a/frontend/src/util/scrollIntoList.ts
+++ b/frontend/src/util/scrollIntoList.ts
@@ -1,0 +1,44 @@
+/**
+ * Scrolls a list so one of its rows is on screen, touching only that list.
+ *
+ * `element.scrollIntoView({ block: "nearest" })` is the obvious way to do this
+ * and is what the menu pages used to call, but it scrolls *every* scrollable
+ * ancestor — the document included. #root's layout box is close to a thousand
+ * pixels tall whatever the screen, so on a short viewport (a landscape phone)
+ * the document overflows and is scrollable even though nothing looks scrollable,
+ * and moving the cursor down a list dragged the whole app up behind the top of
+ * the screen. `overflow: hidden` on html does not prevent that: it removes the
+ * scrollbar, not the ability to be scrolled programmatically.
+ */
+
+const scrollParent = (element: HTMLElement): HTMLElement | null => {
+    let node = element.parentElement;
+    while (node) {
+        const { overflowY } = getComputedStyle(node);
+        if ((overflowY === "auto" || overflowY === "scroll") && node.scrollHeight > node.clientHeight) {
+            return node;
+        }
+        node = node.parentElement;
+    }
+    return null;
+};
+
+export const scrollIntoList = (item: HTMLElement | null | undefined) => {
+    const list = item ? scrollParent(item) : null;
+    if (!item || !list) return;
+
+    const itemBox = item.getBoundingClientRect();
+    const listBox = list.getBoundingClientRect();
+
+    // Rects come back in on-screen pixels and scrollTop is in layout pixels, so
+    // the app's scale has to come out of the difference before it is applied
+    const scale = listBox.height / list.clientHeight || 1;
+
+    // Matches "nearest": move by exactly enough to bring the row inside, and do
+    // nothing at all when it already is
+    if (itemBox.top < listBox.top) {
+        list.scrollTop -= (listBox.top - itemBox.top) / scale;
+    } else if (itemBox.bottom > listBox.bottom) {
+        list.scrollTop += (itemBox.bottom - listBox.bottom) / scale;
+    }
+};

--- a/frontend/src/util/sounds.ts
+++ b/frontend/src/util/sounds.ts
@@ -1,51 +1,181 @@
-type sounds = "select" | "back" | "error" | "materia" | "slash" | "crit" | "limit" | "delete" | "heal" | "save" | "saveSelect" | "fanfare";
+/**
+ * Menu sound effects, played through the Web Audio API.
+ *
+ * The obvious implementation — `new Audio(src).play()` per sound — is what this
+ * replaces, and it behaved badly on iOS in three separate ways:
+ *
+ *  - **Late.** Each call built a fresh element, which then had to fetch (or at
+ *    least re-read) and decode the file before it made a sound. On desktop that
+ *    is fast enough to miss; on a phone the cursor had already moved on.
+ *  - **Silent.** Safari only lets audio start from inside a user gesture. An
+ *    element created in a hover or an effect had no gesture behind it, so the
+ *    first sounds of a session were dropped.
+ *  - **Overlapping.** Nothing tied a sound to the element that made it, so two
+ *    events firing together produced two copies a few milliseconds apart, which
+ *    reads as one smeared sound rather than two.
+ *
+ * Decoding every clip once up front and firing a buffer source per play fixes
+ * all three: playback becomes a scheduling call with no I/O, and one unlock
+ * during the first gesture covers every sound afterwards. The whole set is
+ * ~130KB, so preloading it is cheaper than the stutter of not doing so.
+ */
 
-export const loadSound = (sound: sounds) => {
-    if (typeof window == "undefined") return;
+export type sounds = "select" | "back" | "error" | "materia" | "slash" | "crit" | "limit" | "delete" | "heal" | "save" | "saveSelect" | "fanfare";
 
-    const src = "/audio/";
+const FILES: Record<sounds, string> = {
+    select: "select.mp3",
+    back: "back.mp3",
+    error: "error.mp3",
+    materia: "materia.mp3",
+    slash: "slash.mp3",
+    crit: "crit.mp3",
+    limit: "limit.mp3",
+    delete: "delete.mp3",
+    heal: "heal.mp3",
+    save: "save.mp3",
+    saveSelect: "saveSelect.mp3",
+    fanfare: "fanfare.mp3",
+};
 
-    const sounds = {
-        "select": "select.mp3",
-        "back": "back.mp3",
-        "error": "error.mp3",
-        "materia": "materia.mp3",
-        "slash": "slash.mp3",
-        "crit": "crit.mp3",
-        "limit": "limit.mp3",
-        "delete": "delete.mp3",
-        "heal": "heal.mp3",
-        "save": "save.mp3",
-        "saveSelect": "saveSelect.mp3",
-        "fanfare": "fanfare.mp3",
+const VOLUME = 0.2;
+
+/**
+ * Two events landing on the same element from one tap — a synthetic mouseenter
+ * and the click behind it — used to fire the same clip twice, milliseconds
+ * apart. Identical sounds inside this window collapse to one. It is short
+ * enough that deliberate repeats (a held arrow key repeats no faster than about
+ * 30ms) still sound individually.
+ */
+const DEDUPE_MS = 20;
+
+type WebkitWindow = Window & { webkitAudioContext?: typeof AudioContext };
+
+let context: AudioContext | null = null;
+let contextUnavailable = false;
+
+const buffers = new Map<sounds, AudioBuffer>();
+const loading = new Map<sounds, Promise<void>>();
+const lastPlayed = new Map<sounds, number>();
+
+const getContext = (): AudioContext | null => {
+    if (context || contextUnavailable) return context;
+    if (typeof window === "undefined") return null;
+
+    const Ctor = window.AudioContext ?? (window as WebkitWindow).webkitAudioContext;
+    if (!Ctor) {
+        // Nothing to fall back to, but the menu must not break over a sound
+        contextUnavailable = true;
+        return null;
     }
 
-    return new Audio(`${src}${sounds[sound]}`);
+    context = new Ctor();
+    preload();
+    return context;
+};
+
+const load = (name: sounds): Promise<void> => {
+    const existing = loading.get(name);
+    if (existing) return existing;
+
+    const request = (async () => {
+        const ctx = getContext();
+        if (!ctx) return;
+
+        const response = await fetch(`/audio/${FILES[name]}`);
+        const encoded = await response.arrayBuffer();
+        // Safari's decodeAudioData settles its callbacks, not the promise it returns
+        const decoded = await new Promise<AudioBuffer>((resolve, reject) => {
+            ctx.decodeAudioData(encoded, resolve, reject);
+        });
+        buffers.set(name, decoded);
+    })().catch(() => {
+        // A clip that will not decode should cost silence, not a crash. Drop the
+        // record so a later play retries rather than being stuck on a failure.
+        loading.delete(name);
+    });
+
+    loading.set(name, request);
+    return request;
+};
+
+/** Decodes the whole set, so no single play is the one that pays for loading */
+const preload = () => {
+    (Object.keys(FILES) as sounds[]).forEach(load);
+};
+
+/**
+ * Safari starts the context suspended and only resumes it from inside a user
+ * gesture, so the first tap or key press has to do it. Resuming is most of the
+ * job; the silent one-frame source is what convinces older iOS the context is
+ * genuinely gesture-backed.
+ */
+const unlock = () => {
+    const ctx = getContext();
+    if (!ctx) return;
+
+    if (ctx.state !== "running") void ctx.resume();
+
+    const source = ctx.createBufferSource();
+    source.buffer = ctx.createBuffer(1, 1, ctx.sampleRate);
+    source.connect(ctx.destination);
+    source.start(0);
+};
+
+if (typeof window !== "undefined") {
+    const events = ["pointerdown", "touchend", "keydown"] as const;
+    const onFirstGesture = () => {
+        unlock();
+        events.forEach((type) => window.removeEventListener(type, onFirstGesture));
+    };
+    events.forEach((type) => window.addEventListener(type, onFirstGesture, { passive: true }));
 }
 
-export const playLoadedSound = (audio: HTMLAudioElement | undefined, isSoundEnabled: boolean, isloop: boolean = false) => {
-    if (isSoundEnabled && audio) {
-        if (isloop) audio.loop = true;
-        audio.volume = 0.2;
-        audio.play().catch(() => { });
+const start = (name: sounds, isLoop: boolean) => {
+    const ctx = getContext();
+    const buffer = ctx && buffers.get(name);
+    if (!ctx || !buffer) return;
+
+    const source = ctx.createBufferSource();
+    source.buffer = buffer;
+    source.loop = isLoop;
+
+    const gain = ctx.createGain();
+    gain.gain.value = VOLUME;
+
+    source.connect(gain);
+    gain.connect(ctx.destination);
+    source.start(0);
+
+    // Each play gets its own nodes, so they are released once the clip ends
+    // rather than accumulating across a long session
+    source.onended = () => {
+        source.disconnect();
+        gain.disconnect();
+    };
+};
+
+const playSound = (soundName: sounds, isSoundEnabled: boolean, isLoop: boolean = false) => {
+    if (!isSoundEnabled) return;
+
+    const ctx = getContext();
+    if (!ctx) return;
+
+    const now = performance.now();
+    if (now - (lastPlayed.get(soundName) ?? -Infinity) < DEDUPE_MS) return;
+    lastPlayed.set(soundName, now);
+
+    // A sound asked for outside a gesture — a hover, say — still nudges the
+    // context. A no-op where the browser has already allowed audio.
+    if (ctx.state === "suspended") void ctx.resume();
+
+    if (buffers.has(soundName)) {
+        start(soundName, isLoop);
+        return;
     }
-}
 
-export const stopLoadedSound = (audio: HTMLAudioElement | undefined, isSoundEnabled: boolean) => {
-    if (isSoundEnabled && audio) {
-        audio.pause();
-        audio.currentTime = 0;
-    }
-}
-
-const playSound = (soundName: sounds, isSoundEnabled: boolean, isloop: boolean = false) => {
-    const audio = loadSound(soundName);
-
-    if (isSoundEnabled && audio) {
-        if (isloop) audio.loop = true;
-        audio.volume = 0.2;
-        audio.play().catch(() => { });
-    }
-}
+    // Only reachable in the first moments of a session, before the preload
+    // finishes. Late beats silent, and it corrects itself immediately after.
+    void load(soundName).then(() => start(soundName, isLoop));
+};
 
 export default playSound;

--- a/frontend/src/util/sounds.ts
+++ b/frontend/src/util/sounds.ts
@@ -137,13 +137,38 @@ const unlock = () => {
     source.start(0);
 };
 
-if (typeof window !== "undefined") {
-    const events = ["pointerdown", "touchend", "keydown"] as const;
-    const onFirstGesture = () => {
+/**
+ * Only these count. The activation events a browser will unlock audio on are
+ * pointer and key presses — a hover is not one, which is why no amount of moving
+ * the mouse around the menu will start the sound. touchend is here for iOS,
+ * which treats it as the activation rather than the pointerdown.
+ */
+const GESTURES = ["pointerdown", "touchend", "keydown"] as const;
+
+const armUnlock = () => {
+    const onGesture = () => {
         unlock();
-        events.forEach((type) => window.removeEventListener(type, onFirstGesture));
+        GESTURES.forEach((type) => window.removeEventListener(type, onGesture));
     };
-    events.forEach((type) => window.addEventListener(type, onFirstGesture, { passive: true }));
+    GESTURES.forEach((type) => window.addEventListener(type, onGesture, { passive: true }));
+};
+
+if (typeof window !== "undefined") {
+    armUnlock();
+
+    /**
+     * iOS suspends the context when the page goes into the background, and on an
+     * audio interruption such as a call. Coming back needs a fresh gesture, so
+     * the listeners are put back rather than being a one-time thing — otherwise
+     * sound simply stops working for the rest of the visit.
+     */
+    document.addEventListener("visibilitychange", () => {
+        if (document.visibilityState !== "visible") return;
+        if (context && context.state !== "running") {
+            gestureSeen = false;
+            armUnlock();
+        }
+    });
 }
 
 const start = (name: sounds, isLoop: boolean) => {
@@ -201,9 +226,18 @@ const playSound = (soundName: sounds, isSoundEnabled: boolean, isLoop: boolean =
         return;
     }
 
-    // A gesture has happened but resume() has not settled yet — the first click
-    // of a session. One sound, wanted, so it waits rather than being dropped.
-    void ctx.resume().then(play);
+    /**
+     * A gesture has happened but resume() has not settled yet — the first click
+     * of a session. One sound, wanted, so it waits rather than being dropped.
+     *
+     * Checked again on the way out: resume() settling does not promise the
+     * context actually started, and playing into one that is still suspended is
+     * what schedules a sound for later instead of playing it. That is the
+     * backlog this whole path exists to avoid.
+     */
+    void ctx.resume().then(() => {
+        if (ctx.state === "running") play();
+    });
 };
 
 export default playSound;

--- a/frontend/src/util/sounds.ts
+++ b/frontend/src/util/sounds.ts
@@ -53,6 +53,17 @@ type WebkitWindow = Window & { webkitAudioContext?: typeof AudioContext };
 let context: AudioContext | null = null;
 let contextUnavailable = false;
 
+/**
+ * Whether a user gesture has happened yet. Until one has, the context cannot be
+ * running, and a sound started against a suspended context is not dropped by the
+ * browser — it is scheduled. Every hover on the way to the first click piles up
+ * and the whole backlog fires the moment the context resumes.
+ *
+ * Sound is opt-in, but the setting is remembered, so a returning visitor has it
+ * on before they have touched anything and hits exactly that.
+ */
+let gestureSeen = false;
+
 const buffers = new Map<sounds, AudioBuffer>();
 const loading = new Map<sounds, Promise<void>>();
 const lastPlayed = new Map<sounds, number>();
@@ -110,6 +121,11 @@ const preload = () => {
  * genuinely gesture-backed.
  */
 const unlock = () => {
+    // Set before resume() is even asked for: the click that follows a
+    // pointerdown arrives long before the resume promise settles, and that
+    // click's own sound is one we do want to hear.
+    gestureSeen = true;
+
     const ctx = getContext();
     if (!ctx) return;
 
@@ -160,22 +176,34 @@ const playSound = (soundName: sounds, isSoundEnabled: boolean, isLoop: boolean =
     const ctx = getContext();
     if (!ctx) return;
 
+    // Nothing has unlocked audio yet, so this cannot be heard now and must not
+    // be scheduled for later — that is the backlog. Drop it. Hovering the menu
+    // before the first click is exactly this case, and silence there is correct
+    // rather than a compromise: the browser was never going to play it.
+    if (ctx.state !== "running" && !gestureSeen) return;
+
     const now = performance.now();
     if (now - (lastPlayed.get(soundName) ?? -Infinity) < DEDUPE_MS) return;
     lastPlayed.set(soundName, now);
 
-    // A sound asked for outside a gesture — a hover, say — still nudges the
-    // context. A no-op where the browser has already allowed audio.
-    if (ctx.state === "suspended") void ctx.resume();
+    const play = () => {
+        if (buffers.has(soundName)) {
+            start(soundName, isLoop);
+            return;
+        }
+        // Only reachable in the first moments of a session, before the preload
+        // finishes. Late beats silent, and it corrects itself immediately after.
+        void load(soundName).then(() => start(soundName, isLoop));
+    };
 
-    if (buffers.has(soundName)) {
-        start(soundName, isLoop);
+    if (ctx.state === "running") {
+        play();
         return;
     }
 
-    // Only reachable in the first moments of a session, before the preload
-    // finishes. Late beats silent, and it corrects itself immediately after.
-    void load(soundName).then(() => start(soundName, isLoop));
+    // A gesture has happened but resume() has not settled yet — the first click
+    // of a session. One sound, wanted, so it waits rather than being dropped.
+    void ctx.resume().then(play);
 };
 
 export default playSound;


### PR DESCRIPTION
A batch of unrelated fixes, one commit each so they can be read or reverted
independently.

## Requested

**Name entry takes real keyboard input.** Typing a glyph that exists on the
on-screen keyboard adds it, backspace removes, and anything with no glyph in the
sprite font does nothing rather than being dropped into the name as a gap. The
listener is on the capture phase because `useCursorNav` also listens on `window`
and maps `Space` to *cancel* — a typed space would otherwise have left the page.

**Sounds go through Web Audio.** `new Audio().play()` per sound was late, silent
or doubled on iOS. Clips are decoded once and played as buffer sources, so
playback is a scheduling call with no I/O, and the first gesture unlocks the
context and preloads the rest (~130KB).

The doubling had a second cause in the menu rather than the audio: a tap
synthesises a `mouseenter` as well as the `click`, so one finger fired both the
hover and the click sound. Hover is now mouse-only, matching the guard the
Projects and Equip lists already used.

Sounds raised before any gesture are now dropped rather than queued — a sound
started against a suspended context is *scheduled*, not discarded, so hovers
piled up and fired together on the first click. The first gesture is still
audible, and the unlock re-arms after iOS suspends the context on backgrounding.

**Project navigation freezes while the captures are open.** Stepping to image 4
of 4 and then arrowing to an entry with two captures crashed the app with
`Cannot read properties of undefined`. Reproduced, then confirmed fixed.

**Scrollbar thumb stays in its track.** `scrollTop` is not bounded on iOS —
rubber-banding reports negative at the top and past the end at the bottom, which
put the thumb outside its track and sprang it back on release.

**History header no longer blinks.** It was rendered three times over, once each
by the option list, the loading bar and the save list, so it faded out and back
in at every step. One box now; only the text changes. Its cursor also waits for
the rows to finish fading in rather than appearing over an empty panel, and it
starts on the row the mouse is actually over — the list opens under a stationary
pointer, so no `mouseenter` fires and the cursor used to disagree with what a
click would hit.

**Mobile uses more of the screen.** The design canvas was wider and taller than
anything ever reached: 1250x975 against a 1100x825 stage. It is 1200 wide now,
and phone-sized viewports scale to an 880-tall canvas, which is about 11% larger
in landscape. Desktop is deliberately untouched — verified identical at 1440x900,
1920x1080, a narrow 1000x900 window and both iPad orientations.

**White bands beside the notch.** The root element had no background; iOS insets
the layout viewport and the bands that leaves sit outside `body`. Also sets
`theme-color` and `color-scheme` so the browser chrome goes dark.

## Found while in there

**The captures overlay did not cover the whole screen on mobile.** It is
`position: fixed` inside a transformed `#root`, so `inset: 0` meant *#root's box*
rather than the viewport, and the close button's overhang stayed lit above the
dimmed page.

**Skills was clipped in landscape.** The list pages used
`scrollIntoView({ block: "nearest" })`, which scrolls every scrollable ancestor
including the document — and on a short viewport the document overflows, so
Skills' own mount dragged the whole app off the top. There is a `scrollIntoList`
helper now that only touches the list.

## Verified

Lint and build clean. Sounds measured across every page (one clip per keypress,
one per touch tap, none before a gesture). Layout checked for clipping on iPhone
SE, iPhone 13, 14 Pro Max, Pixel 7, both iPad orientations, and desktop at three
sizes. The carousel crash, the scrollbar overscroll, the history cursor mismatch
and the audio backlog were each reproduced before and confirmed after.

**Not verified:** real audio playback on iOS or Android hardware — that needs the
host. Everything here was measured in Chrome, with the AudioContext forced into
the suspended state a real browser starts in, since headless ignores the autoplay
policy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LdYU2RGc6dX348wjxQg8J7